### PR TITLE
Adds the possibility to render left to right

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,18 @@ This is what `smcat --help` would get you:
 ```
 Usage: smcat [options] [infile]
 
+
 Options:
 
-  -h, --help               output usage information
   -V, --version            output the version number
-  -T --output-type <type>  smcat|dot|json|ast|svg. Default: svg
+  -T --output-type <type>  smcat|dot|json|ast|svg|html. Default: svg
   -I --input-type <type>   smcat|json. Default: smcat
   -E --engine <type>       dot|circo|fdp|neato|osage|twopi. Default: dot
+  -d --direction <dir>     top-down|left-right. Default: top-down
   -i --input-from <file>   File to read from. use - for stdin.
   -o --output-to <file>    File to write to. use - for stdout.
   -l --license             Display license and exit
+  -h, --help               output usage information
 ```
 
 ... so to convert the above chart to `sample.svg`
@@ -206,8 +208,6 @@ b => ]join;
 
 ![rendition](https://gitlab.com/sverweij/state-machine-cat/raw/master/doc/pics/03bforkjoin.png)
 
-
-
 #### Gotchas
 - when you need `;`, `,`, `{` or spaces as part of a state - place em in quotes
     `"a state"`
@@ -264,8 +264,6 @@ I made the parser with pegjs - you can find it at
 - Despite this you might bump into the occasional issue - don't hesitate to
   report it, either on [GitLab](https://gitlab.com/sverweij/state-machine-cat/issues)
   or on [GitHub](https://github.com/sverweij/state-machine-cat/issues).
-- It's also an 1.x.x version - so I might change some things around (always
-  respectful of the _semantic versioning_ guidelines).
 - Runs on latest versions of firefox, safari and chrome and node versions >= 6.
   Although it might run on other environments, it's not tested there. I will
   reject issues on these other environments, unless they're accompanied with

--- a/bin/smcat
+++ b/bin/smcat
@@ -36,6 +36,10 @@ try {
             validations.validEngineRE + ". Default: dot",
             validations.validEngine
         ).option(
+            "-d --direction <dir>",
+            validations.validDirectionRE + ". Default: top-down",
+            validations.validDirection
+        ).option(
             "-i --input-from <file>",
             "File to read from. use - for stdin."
         ).option(

--- a/doc/index-klunky.html
+++ b/doc/index-klunky.html
@@ -86,6 +86,15 @@ a {
                 </select>
             </fieldset>
             <fieldset>
+                <legend>Direction</legend>
+                <label for="top-down">
+                    <input id="top-down" type="radio" name="directionrg" checked>top down</input>
+                </label>
+                <label for="left-right">
+                    <input id="left-right" type="radio" name="directionrg">left right</input>
+                </label>
+            </fieldset>
+            <fieldset>
                 <legend>Render</legend>
                 <label for="autorender">
                     <input type="checkbox" id="autorender" checked="true"></input>

--- a/doc/index.html
+++ b/doc/index.html
@@ -106,7 +106,7 @@
               <li class="mdl-list__item">
                 <span class="mdl-list__item-primary-content">
                     <i class="material-icons mdl-list__item-icon">copyright</i>
-                    <a class="mdl-navigation__link" href="https://gitlab.com/sverweij/state-machine-cat/blob/master/LICENSE.md">Sander Verweij 2016</a>
+                    <a class="mdl-navigation__link" href="https://gitlab.com/sverweij/state-machine-cat/blob/master/LICENSE.md">Sander Verweij 2016-2017</a>
                 </span>
               </li>
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -87,6 +87,8 @@
                     </label>
                 </span>
               </li>
+
+
               <li class="mdl-list__item">
                 <span class="mdl-list__item-primary-content">
                     <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="autorender">
@@ -95,6 +97,25 @@
                     </label>
                 </span>
               </li>
+
+              <li class="mdl-list__item">
+                <span class="mdl-list__item-primary-content">
+                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="top-down">
+                      <input type="radio" id="top-down" class="mdl-radio__button" name="directionrg" value="top-down" checked>
+                      <span class="mdl-radio__label">top down</span>
+                    </label>
+                </span>
+              </li>
+
+              <li class="mdl-list__item">
+                <span class="mdl-list__item-primary-content">
+                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="left-right">
+                      <input type="radio" id="left-right" class="mdl-radio__button" name="directionrg" value="left-right">
+                      <span class="mdl-radio__label">left right</span>
+                    </label>
+                </span>
+              </li>
+
               <li class="mdl-list__item mdl-menu__item--full-bleed-divider"></li>
 
               <li class="mdl-list__item">

--- a/doc/index.html
+++ b/doc/index.html
@@ -47,71 +47,76 @@
             }
             </style>
             <ul class="demo-list-item mdl-list">
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="svg">
-                      <input type="radio" id="svg" class="mdl-radio__button" name="options" value="svg" checked>
-                      <span class="mdl-radio__label">SVG</span>
-                    </label>
-                </span>
-              </li>
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="dot">
-                      <input type="radio" id="dot" class="mdl-radio__button" name="options" value="dot">
-                      <span class="mdl-radio__label">DOT</span>
-                    </label>
-                </span>
-              </li>
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="json">
-                      <input type="radio" id="json" class="mdl-radio__button" name="options" value="json">
-                      <span class="mdl-radio__label">JSON</span>
-                    </label>
-                </span>
-              </li>
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="smcat">
-                      <input type="radio" id="smcat" class="mdl-radio__button" name="options" value="smcat">
-                      <span class="mdl-radio__label">SMCAT</span>
-                    </label>
-                </span>
-              </li>
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="html">
-                      <input type="radio" id="html" class="mdl-radio__button" name="options" value="html">
-                      <span class="mdl-radio__label">table</span>
-                    </label>
-                </span>
-              </li>
+                <fieldset>
+                  <legend>Output type</legend>
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="svg">
+                          <input type="radio" id="svg" class="mdl-radio__button" name="options" value="svg" checked>
+                          <span class="mdl-radio__label">SVG</span>
+                        </label>
+                    </span>
+                  </li>
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="dot">
+                          <input type="radio" id="dot" class="mdl-radio__button" name="options" value="dot">
+                          <span class="mdl-radio__label">DOT</span>
+                        </label>
+                    </span>
+                  </li>
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="json">
+                          <input type="radio" id="json" class="mdl-radio__button" name="options" value="json">
+                          <span class="mdl-radio__label">JSON</span>
+                        </label>
+                    </span>
+                  </li>
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="smcat">
+                          <input type="radio" id="smcat" class="mdl-radio__button" name="options" value="smcat">
+                          <span class="mdl-radio__label">SMCAT</span>
+                        </label>
+                    </span>
+                  </li>
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="html">
+                          <input type="radio" id="html" class="mdl-radio__button" name="options" value="html">
+                          <span class="mdl-radio__label">table</span>
+                        </label>
+                    </span>
+                  </li>
+              </fieldset>
 
+              <fieldset>
+                  <legend>direction</legend>
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="top-down">
+                          <input type="radio" id="top-down" class="mdl-radio__button" name="directionrg" value="top-down" checked>
+                          <span class="mdl-radio__label">top down</span>
+                        </label>
+                    </span>
+                  </li>
+
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="left-right">
+                          <input type="radio" id="left-right" class="mdl-radio__button" name="directionrg" value="left-right">
+                          <span class="mdl-radio__label">left to right</span>
+                        </label>
+                    </span>
+                  </li>
+              </fieldset>
 
               <li class="mdl-list__item">
                 <span class="mdl-list__item-primary-content">
                     <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="autorender">
                       <input type="checkbox" id="autorender" class="mdl-switch__input" checked>
                       <span class="mdl-switch__label">render automatically</span>
-                    </label>
-                </span>
-              </li>
-
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="top-down">
-                      <input type="radio" id="top-down" class="mdl-radio__button" name="directionrg" value="top-down" checked>
-                      <span class="mdl-radio__label">top down</span>
-                    </label>
-                </span>
-              </li>
-
-              <li class="mdl-list__item">
-                <span class="mdl-list__item-primary-content">
-                    <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="left-right">
-                      <input type="radio" id="left-right" class="mdl-radio__button" name="directionrg" value="left-right">
-                      <span class="mdl-radio__label">left right</span>
                     </label>
                 </span>
               </li>

--- a/doc/smcat-online-interpreter.js
+++ b/doc/smcat-online-interpreter.js
@@ -143,6 +143,6 @@ define(function (require) {
 
     setTextAreaToWindowHeight();
     window.version.innerHTML = "SM-cat ${version}".replace("${version}", smcat.version);
-    render(gCurrentRenderer);
+    render(gCurrentRenderer, gCurrentEngine, gCurrentDirection);
 
 });

--- a/doc/smcat-online-interpreter.js
+++ b/doc/smcat-online-interpreter.js
@@ -15,7 +15,8 @@ define(function (require) {
             {
                 inputType: "smcat",
                 outputType: pType,
-                engine: pEngine
+                engine: pEngine,
+                direction: "left-right"
             },
             function (pError, pSuccess){
                 if (Boolean(pError)){

--- a/doc/smcat-online-interpreter.js
+++ b/doc/smcat-online-interpreter.js
@@ -1,13 +1,16 @@
 define(function (require) {
     var smcat = require('../src/index');
-    var gCurrentRenderer = "svg";
-    var gCurrentEngine   = "dot";
+    var gCurrentRenderer  = "svg";
+    var gCurrentEngine    = "dot";
+    var gCurrentDirection = "top-down";
 
-    function render(pType, pEngine){
+    function render(pType, pEngine, pDirection){
         pType = Boolean(pType) ? pType : gCurrentRenderer;
         gCurrentRenderer = pType;
         pEngine = Boolean(pEngine) ? pEngine : gCurrentEngine;
         gCurrentEngine = pEngine;
+        pDirection = Boolean(pDirection) ? pDirection : gCurrentDirection;
+        gCurrentDirection = pDirection;
 
         window.output.innerHTML = "";
         smcat.render(
@@ -16,7 +19,7 @@ define(function (require) {
                 inputType: "smcat",
                 outputType: pType,
                 engine: pEngine,
-                direction: "left-right"
+                direction: pDirection
             },
             function (pError, pSuccess){
                 if (Boolean(pError)){
@@ -87,6 +90,22 @@ define(function (require) {
             if (window.autorender.checked){
                 render();
             }
+        },
+        false
+    );
+
+    window["top-down"].addEventListener(
+        "click",
+        function(){
+            render(null, null, "top-down");
+        },
+        false
+    );
+
+    window["left-right"].addEventListener(
+        "click",
+        function(){
+            render(null, null, "left-right");
         },
         false
     );

--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -94,7 +94,8 @@ module.exports = (() => {
                 {
                     inputType: pOptions.inputType,
                     outputType: pOptions.outputType,
-                    engine: pOptions.engine
+                    engine: pOptions.engine,
+                    direction: pOptions.direction
                 },
                 (pError, pSuccess) =>
                     callback2Promise(pError, pSuccess, pResolve, pReject)

--- a/src/cli/normalizations.js
+++ b/src/cli/normalizations.js
@@ -92,7 +92,7 @@ module.exports = (() => {
          * @return {object} a commander options object with options 'normalized'
          */
         normalize (pArgument, pOptions) {
-            let lRetval = JSON.parse(JSON.stringify(pOptions));
+            let lRetval = Object.assign({}, pOptions);
 
             lRetval.inputFrom  = Boolean(pArgument) ? pArgument : pOptions.inputFrom;
             lRetval.inputType  =
@@ -115,7 +115,10 @@ module.exports = (() => {
                 pOptions.hasOwnProperty("engine")
                     ? pOptions.engine
                     : "dot";
-
+            lRetval.direction =
+                pOptions.hasOwnProperty("direction")
+                    ? pOptions.direction
+                    : "top-down";
             return lRetval;
         }
     };

--- a/src/cli/validations.js
+++ b/src/cli/validations.js
@@ -8,10 +8,10 @@ module.exports = (() => {
         smcat.getAllowedValues().outputType.map(pValue => pValue.name);
     const VALID_INPUT_TYPES =
         smcat.getAllowedValues().inputType.map(pValue => pValue.name);
-
     const VALID_ENGINES =
         smcat.getAllowedValues().engine.map(pValue => pValue.name);
-
+    const VALID_DIRECTIONS =
+        smcat.getAllowedValues().direction.map(pValue => pValue.name);
 
     function isStdout(pFilename) {
         return "-" === pFilename;
@@ -61,6 +61,17 @@ module.exports = (() => {
 
         },
 
+        validDirection(pDirection) {
+            if (VALID_DIRECTIONS.some(pName => pName === pDirection)){
+                return pDirection;
+            }
+
+            throw Error(
+                `\n  error: '${pDirection}' is not a valid direction.` +
+                `\n         you can choose from ${VALID_DIRECTIONS.join(", ")}\n\n`);
+
+        },
+
         validateArguments(pOptions) {
             return new Promise((pResolve, pReject) => {
                 if (!pOptions.inputFrom) {
@@ -83,7 +94,9 @@ module.exports = (() => {
 
         validInputTypeRE: VALID_INPUT_TYPES.join("|"),
 
-        validEngineRE: VALID_ENGINES.join("|")
+        validEngineRE: VALID_ENGINES.join("|"),
+
+        validDirectionRE: VALID_DIRECTIONS.join("|")
 
     };
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -81,10 +81,10 @@ define(function(require) {
                     pCallBack(null, ast2smcat.render(lAST));
                     break;
                 case "dot":
-                    pCallBack(null, ast2dot.render(lAST));
+                    pCallBack(null, ast2dot.render(lAST, pOptions));
                     break;
                 case "svg":
-                    pCallBack(null, viz(ast2dot.render(lAST), {engine: determineEngine(pOptions)}));
+                    pCallBack(null, viz(ast2dot.render(lAST, pOptions), {engine: determineEngine(pOptions)}));
                     break;
                 case "html":
                     pCallBack(null, ast2HTMLTable.render(lAST));
@@ -137,6 +137,10 @@ define(function(require) {
                     {name: "neato",  experimental: false},
                     {name: "osage",  experimental: false},
                     {name: "twopi",  experimental: false}
+                ],
+                direction: [
+                    {name: "top-down",   experimental: true},
+                    {name: "left-right", experimental: true}
                 ]
             });
         }

--- a/src/render/ast2dot.js
+++ b/src/render/ast2dot.js
@@ -85,6 +85,21 @@ define(function(require) {
         };
     }
 
+    function tipForkJoinStates(pDirection) {
+        return function (pState) {
+            if (_.isType("forkjoin")(pState)){
+                return Object.assign(
+                    {
+                        sizingExtras: (pDirection || "top-down") === "top-down" ? "height=0.1" : "width=0.1"
+                    },
+                    pState
+                );
+            } else {
+                return pState;
+            }
+        };
+    }
+
     function transformStates(pStates, pDirection) {
         pStates
             .filter(_.isType("composite"))
@@ -96,7 +111,8 @@ define(function(require) {
             .map(nameNote)
             .map(escapeStrings)
             .map(flattenNote)
-            .map(setLabel(pDirection));
+            .map(setLabel(pDirection))
+            .map(tipForkJoinStates(pDirection));
     }
 
     function transformStatesFromAnAST(pAST, pDirection) {

--- a/src/render/dot.states.template.hbs
+++ b/src/render/dot.states.template.hbs
@@ -5,11 +5,11 @@
   "{{{name}}}" [label="{{{label}}}"]
 {{/regularStates}}
 {{#choiceStates}}
-  "{{{name}}}" [shape=diamond fixedsize=shape width=0.35 height=0.35 fontsize=10 label=" "]
+  "{{{name}}}" [shape=diamond fixedsize=true width=0.35 height=0.35 fontsize=10 label=" "]
   "{{{name}}}" -> "{{{name}}}" [label="{{#activities}}{{{.}}}{{/activities~}}" color=transparent];
 {{/choiceStates}}
 {{#forkjoinStates}}
-  "{{{name}}}" [shape=rect label=" " {{#if ../direction}}{{else}}fixedsize=shape {{/if~}} style=filled fillcolor=black {{#if ../direction}}width{{else}}height{{/if}}=0.1]
+  "{{{name}}}" [shape=rect label=" " fixedsize=true style=filled fillcolor=black {{{sizingExtras}}}]
 {{/forkjoinStates}}
 {{#finalStates}}
   "{{{name}}}" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=""]
@@ -17,7 +17,7 @@
 {{#compositeStates}}
   subgraph "cluster_{{{name}}}" {
     label="{{{name}}}" style=rounded penwidth=2.0
-    "{{{name}}}" [shape=point style=invis margin=0 width=0 height=0]
+    "{{{name}}}" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
     {{#stateSection statemachine}}{{/stateSection}}
   }
 {{/compositeStates}}

--- a/src/render/dot.states.template.hbs
+++ b/src/render/dot.states.template.hbs
@@ -2,14 +2,14 @@
   "{{{name}}}" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 label=""]
 {{/initialStates}}
 {{#regularStates}}
-  "{{{name}}}" [label="{ {{~{name}}}{{#activities}}|{{{.}}}{{/activities~}} }"]
+  "{{{name}}}" [label="{{{label}}}"]
 {{/regularStates}}
 {{#choiceStates}}
   "{{{name}}}" [shape=diamond fixedsize=shape width=0.35 height=0.35 fontsize=10 label=" "]
   "{{{name}}}" -> "{{{name}}}" [label="{{#activities}}{{{.}}}{{/activities~}}" color=transparent];
 {{/choiceStates}}
 {{#forkjoinStates}}
-  "{{{name}}}" [shape=rect label=" " fixedsize=shape style=filled fillcolor=black height=0.1]
+  "{{{name}}}" [shape=rect label=" " {{#if ../direction}}{{else}}fixedsize=shape {{/if~}} style=filled fillcolor=black {{#if ../direction}}width{{else}}height{{/if}}=0.1]
 {{/forkjoinStates}}
 {{#finalStates}}
   "{{{name}}}" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=""]

--- a/src/render/dot.states.template.js
+++ b/src/render/dot.states.template.js
@@ -22,7 +22,7 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
   "  \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
-    + "\" [shape=diamond fixedsize=shape width=0.35 height=0.35 fontsize=10 label=\" \"]\n  \""
+    + "\" [shape=diamond fixedsize=true width=0.35 height=0.35 fontsize=10 label=\" \"]\n  \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" -> \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
@@ -35,31 +35,21 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
     var stack1;
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"8":function(container,depth0,helpers,partials,data,blockParams,depths) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+},"8":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function";
 
   return "  \""
-    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
-    + "\" [shape=rect label=\" \" "
-    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].direction : depths[1]),{"name":"if","hash":{},"fn":container.program(9, data, 0, blockParams, depths),"inverse":container.program(11, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
-    + "style=filled fillcolor=black "
-    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].direction : depths[1]),{"name":"if","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.program(15, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
-    + "=0.1]\n";
-},"9":function(container,depth0,helpers,partials,data) {
-    return "";
-},"11":function(container,depth0,helpers,partials,data) {
-    return "fixedsize=shape ";
-},"13":function(container,depth0,helpers,partials,data) {
-    return "width";
-},"15":function(container,depth0,helpers,partials,data) {
-    return "height";
-},"17":function(container,depth0,helpers,partials,data) {
+    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
+    + "\" [shape=rect label=\" \" fixedsize=true style=filled fillcolor=black "
+    + ((stack1 = ((helper = (helper = helpers.sizingExtras || (depth0 != null ? depth0.sizingExtras : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"sizingExtras","hash":{},"data":data}) : helper))) != null ? stack1 : "")
+    + "]\n";
+},"10":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
   return "  \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=\"\"]\n";
-},"19":function(container,depth0,helpers,partials,data) {
+},"12":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function";
 
   return "  subgraph \"cluster_"
@@ -68,17 +58,19 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" style=rounded penwidth=2.0\n    \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
-    + "\" [shape=point style=invis margin=0 width=0 height=0]\n    "
-    + ((stack1 = (helpers.stateSection || (depth0 && depth0.stateSection) || alias2).call(alias1,(depth0 != null ? depth0.statemachine : depth0),{"name":"stateSection","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]\n    "
+    + ((stack1 = (helpers.stateSection || (depth0 && depth0.stateSection) || alias2).call(alias1,(depth0 != null ? depth0.statemachine : depth0),{"name":"stateSection","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n  }\n";
-},"21":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"13":function(container,depth0,helpers,partials,data) {
+    return "";
+},"15":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, buffer = "";
 
-  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"noteName","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"noteName","hash":{},"fn":container.program(16, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.noteName) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer;
-},"22":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"16":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, alias1=container.lambda;
 
   return "    \""
@@ -105,13 +97,13 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
   stack1 = ((helper = (helper = helpers.forkjoinStates || (depth0 != null ? depth0.forkjoinStates : depth0)) != null ? helper : alias2),(options={"name":"forkjoinStates","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.forkjoinStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.finalStates || (depth0 != null ? depth0.finalStates : depth0)) != null ? helper : alias2),(options={"name":"finalStates","hash":{},"fn":container.program(17, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.finalStates || (depth0 != null ? depth0.finalStates : depth0)) != null ? helper : alias2),(options={"name":"finalStates","hash":{},"fn":container.program(10, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.finalStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.compositeStates || (depth0 != null ? depth0.compositeStates : depth0)) != null ? helper : alias2),(options={"name":"compositeStates","hash":{},"fn":container.program(19, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.compositeStates || (depth0 != null ? depth0.compositeStates : depth0)) != null ? helper : alias2),(options={"name":"compositeStates","hash":{},"fn":container.program(12, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.compositeStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.states || (depth0 != null ? depth0.states : depth0)) != null ? helper : alias2),(options={"name":"states","hash":{},"fn":container.program(21, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.states || (depth0 != null ? depth0.states : depth0)) != null ? helper : alias2),(options={"name":"states","hash":{},"fn":container.program(15, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.states) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer;

--- a/src/render/dot.states.template.js
+++ b/src/render/dot.states.template.js
@@ -11,21 +11,14 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 label=\"\"]\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
-  "  \""
-    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
-    + "\" [label=\"{"
-    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "");
-  stack1 = ((helper = (helper = helpers.activities || (depth0 != null ? depth0.activities : depth0)) != null ? helper : alias2),(options={"name":"activities","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
-  if (!helpers.activities) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "}\"]\n";
-},"4":function(container,depth0,helpers,partials,data) {
-    var stack1;
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function";
 
-  return "|"
-    + ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"6":function(container,depth0,helpers,partials,data) {
+  return "  \""
+    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
+    + "\" [label=\""
+    + ((stack1 = ((helper = (helper = helpers.label || (depth0 != null ? depth0.label : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"label","hash":{},"data":data}) : helper))) != null ? stack1 : "")
+    + "\"]\n";
+},"5":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
   "  \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
@@ -34,27 +27,39 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
     + "\" -> \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" [label=\"";
-  stack1 = ((helper = (helper = helpers.activities || (depth0 != null ? depth0.activities : depth0)) != null ? helper : alias2),(options={"name":"activities","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.activities || (depth0 != null ? depth0.activities : depth0)) != null ? helper : alias2),(options={"name":"activities","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.activities) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "\" color=transparent];\n";
-},"7":function(container,depth0,helpers,partials,data) {
+},"6":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"9":function(container,depth0,helpers,partials,data) {
-    var stack1, helper;
+},"8":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "  \""
-    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
-    + "\" [shape=rect label=\" \" fixedsize=shape style=filled fillcolor=black height=0.1]\n";
+    + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
+    + "\" [shape=rect label=\" \" "
+    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].direction : depths[1]),{"name":"if","hash":{},"fn":container.program(9, data, 0, blockParams, depths),"inverse":container.program(11, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + "style=filled fillcolor=black "
+    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].direction : depths[1]),{"name":"if","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.program(15, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + "=0.1]\n";
+},"9":function(container,depth0,helpers,partials,data) {
+    return "";
 },"11":function(container,depth0,helpers,partials,data) {
+    return "fixedsize=shape ";
+},"13":function(container,depth0,helpers,partials,data) {
+    return "width";
+},"15":function(container,depth0,helpers,partials,data) {
+    return "height";
+},"17":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
   return "  \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=\"\"]\n";
-},"13":function(container,depth0,helpers,partials,data) {
+},"19":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function";
 
   return "  subgraph \"cluster_"
@@ -64,18 +69,16 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
     + "\" style=rounded penwidth=2.0\n    \""
     + ((stack1 = ((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" [shape=point style=invis margin=0 width=0 height=0]\n    "
-    + ((stack1 = (helpers.stateSection || (depth0 && depth0.stateSection) || alias2).call(alias1,(depth0 != null ? depth0.statemachine : depth0),{"name":"stateSection","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = (helpers.stateSection || (depth0 && depth0.stateSection) || alias2).call(alias1,(depth0 != null ? depth0.statemachine : depth0),{"name":"stateSection","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n  }\n";
-},"14":function(container,depth0,helpers,partials,data) {
-    return "";
-},"16":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"21":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, buffer = "";
 
-  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"noteName","hash":{},"fn":container.program(17, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"noteName","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.noteName) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer;
-},"17":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"22":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, alias1=container.lambda;
 
   return "    \""
@@ -96,19 +99,19 @@ return templates['dot.states.template.hbs'] = template({"1":function(container,d
   stack1 = ((helper = (helper = helpers.regularStates || (depth0 != null ? depth0.regularStates : depth0)) != null ? helper : alias2),(options={"name":"regularStates","hash":{},"fn":container.program(3, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.regularStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.choiceStates || (depth0 != null ? depth0.choiceStates : depth0)) != null ? helper : alias2),(options={"name":"choiceStates","hash":{},"fn":container.program(6, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.choiceStates || (depth0 != null ? depth0.choiceStates : depth0)) != null ? helper : alias2),(options={"name":"choiceStates","hash":{},"fn":container.program(5, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.choiceStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.forkjoinStates || (depth0 != null ? depth0.forkjoinStates : depth0)) != null ? helper : alias2),(options={"name":"forkjoinStates","hash":{},"fn":container.program(9, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.forkjoinStates || (depth0 != null ? depth0.forkjoinStates : depth0)) != null ? helper : alias2),(options={"name":"forkjoinStates","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.forkjoinStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.finalStates || (depth0 != null ? depth0.finalStates : depth0)) != null ? helper : alias2),(options={"name":"finalStates","hash":{},"fn":container.program(11, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.finalStates || (depth0 != null ? depth0.finalStates : depth0)) != null ? helper : alias2),(options={"name":"finalStates","hash":{},"fn":container.program(17, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.finalStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.compositeStates || (depth0 != null ? depth0.compositeStates : depth0)) != null ? helper : alias2),(options={"name":"compositeStates","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.compositeStates || (depth0 != null ? depth0.compositeStates : depth0)) != null ? helper : alias2),(options={"name":"compositeStates","hash":{},"fn":container.program(19, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.compositeStates) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.states || (depth0 != null ? depth0.states : depth0)) != null ? helper : alias2),(options={"name":"states","hash":{},"fn":container.program(16, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.states || (depth0 != null ? depth0.states : depth0)) != null ? helper : alias2),(options={"name":"states","hash":{},"fn":container.program(21, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.states) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer;

--- a/src/render/dot.template.hbs
+++ b/src/render/dot.template.hbs
@@ -14,7 +14,7 @@ digraph "state transitions" {
                             {{~#toComposite}} lhead="cluster_{{{to}}}"{{/toComposite}}]
   {{/noteName}}
   {{#noteName}}
-      "i_{{{.}}}" [shape=point style=invis margin=0 width=0 height=0]
+      "i_{{{.}}}" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "{{{../from}}}" -> "i_{{{.}}}" [arrowhead=none
                                 {{~#../fromComposite}} ltail="cluster_{{{../from}}}"{{/../fromComposite}}]
       "i_{{{.}}}" -> "{{{../to}}}" [label="{{^../label}} {{/../label}}{{{../label}}}"

--- a/src/render/dot.template.hbs
+++ b/src/render/dot.template.hbs
@@ -1,6 +1,7 @@
 digraph "state transitions" {
   splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16
   fontname="Helvetica" fontsize=12 penwidth=2.0
+  {{#direction}}rankdir={{.}}{{/direction}}
   node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]
   edge [fontname=Helvetica fontsize=10]
 

--- a/src/render/dot.template.js
+++ b/src/render/dot.template.js
@@ -4,50 +4,53 @@ if (typeof define !== 'function') {
 }
 define(['../lib/handlebars.runtime'], function(Handlebars) {
   Handlebars = Handlebars["default"];  var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};
-return templates['dot.template.hbs'] = template({"1":function(container,depth0,helpers,partials,data,blockParams,depths) {
+return templates['dot.template.hbs'] = template({"1":function(container,depth0,helpers,partials,data) {
+    return "rankdir="
+    + container.escapeExpression(container.lambda(depth0, depth0));
+},"3":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=helpers.blockHelperMissing, buffer = "";
 
-  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : alias2),(options={"name":"noteName","hash":{},"fn":container.noop,"inverse":container.program(2, data, 0, blockParams, depths),"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : alias2),(options={"name":"noteName","hash":{},"fn":container.noop,"inverse":container.program(4, data, 0, blockParams, depths),"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.noteName) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : alias2),(options={"name":"noteName","hash":{},"fn":container.program(9, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.noteName || (depth0 != null ? depth0.noteName : depth0)) != null ? helper : alias2),(options={"name":"noteName","hash":{},"fn":container.program(11, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.noteName) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer;
-},"2":function(container,depth0,helpers,partials,data) {
+},"4":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=helpers.blockHelperMissing, buffer = 
   "    \""
     + ((stack1 = ((helper = (helper = helpers.from || (depth0 != null ? depth0.from : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"from","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" -> \""
     + ((stack1 = ((helper = (helper = helpers.to || (depth0 != null ? depth0.to : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"to","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\" [label=\"";
-  stack1 = ((helper = (helper = helpers.label || (depth0 != null ? depth0.label : depth0)) != null ? helper : alias2),(options={"name":"label","hash":{},"fn":container.noop,"inverse":container.program(3, data, 0),"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.label || (depth0 != null ? depth0.label : depth0)) != null ? helper : alias2),(options={"name":"label","hash":{},"fn":container.noop,"inverse":container.program(5, data, 0),"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.label) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   buffer += ((stack1 = ((helper = (helper = helpers.label || (depth0 != null ? depth0.label : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"label","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\"";
-  stack1 = ((helper = (helper = helpers.fromComposite || (depth0 != null ? depth0.fromComposite : depth0)) != null ? helper : alias2),(options={"name":"fromComposite","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.fromComposite || (depth0 != null ? depth0.fromComposite : depth0)) != null ? helper : alias2),(options={"name":"fromComposite","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.fromComposite) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  stack1 = ((helper = (helper = helpers.toComposite || (depth0 != null ? depth0.toComposite : depth0)) != null ? helper : alias2),(options={"name":"toComposite","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.toComposite || (depth0 != null ? depth0.toComposite : depth0)) != null ? helper : alias2),(options={"name":"toComposite","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.toComposite) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "]\n";
-},"3":function(container,depth0,helpers,partials,data) {
-    return " ";
 },"5":function(container,depth0,helpers,partials,data) {
+    return " ";
+},"7":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
   return " ltail=\"cluster_"
     + ((stack1 = ((helper = (helper = helpers.from || (depth0 != null ? depth0.from : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"from","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\"";
-},"7":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
   return " lhead=\"cluster_"
     + ((stack1 = ((helper = (helper = helpers.to || (depth0 != null ? depth0.to : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"to","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\"";
-},"9":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"11":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, alias1=container.lambda, alias2=helpers.blockHelperMissing;
 
   return "      \"i_"
@@ -57,16 +60,16 @@ return templates['dot.template.hbs'] = template({"1":function(container,depth0,h
     + "\" -> \"i_"
     + ((stack1 = alias1(depth0, depth0)) != null ? stack1 : "")
     + "\" [arrowhead=none"
-    + ((stack1 = alias2.call(depth0,alias1((depths[1] != null ? depths[1].fromComposite : depths[1]), depth0),{"name":"../fromComposite","hash":{},"fn":container.program(10, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = alias2.call(depth0,alias1((depths[1] != null ? depths[1].fromComposite : depths[1]), depth0),{"name":"../fromComposite","hash":{},"fn":container.program(12, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "]\n      \"i_"
     + ((stack1 = alias1(depth0, depth0)) != null ? stack1 : "")
     + "\" -> \""
     + ((stack1 = alias1((depths[1] != null ? depths[1].to : depths[1]), depth0)) != null ? stack1 : "")
     + "\" [label=\""
-    + ((stack1 = alias2.call(depth0,alias1((depths[1] != null ? depths[1].label : depths[1]), depth0),{"name":"../label","hash":{},"fn":container.noop,"inverse":container.program(3, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + ((stack1 = alias2.call(depth0,alias1((depths[1] != null ? depths[1].label : depths[1]), depth0),{"name":"../label","hash":{},"fn":container.noop,"inverse":container.program(5, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + ((stack1 = alias1((depths[1] != null ? depths[1].label : depths[1]), depth0)) != null ? stack1 : "")
     + "\""
-    + ((stack1 = alias2.call(depth0,alias1((depths[1] != null ? depths[1].toComposite : depths[1]), depth0),{"name":"../toComposite","hash":{},"fn":container.program(12, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = alias2.call(depth0,alias1((depths[1] != null ? depths[1].toComposite : depths[1]), depth0),{"name":"../toComposite","hash":{},"fn":container.program(14, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "]\n      \"i_"
     + ((stack1 = alias1(depth0, depth0)) != null ? stack1 : "")
     + "\" -> \""
@@ -76,25 +79,29 @@ return templates['dot.template.hbs'] = template({"1":function(container,depth0,h
     + "\" [label=\""
     + ((stack1 = alias1((depths[1] != null ? depths[1].noteFlattened : depths[1]), depth0)) != null ? stack1 : "")
     + "\" shape=note fontsize=10 fillcolor=\"#ffffcc\" penwidth=1.0]\n";
-},"10":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"12":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return " ltail=\"cluster_"
     + ((stack1 = container.lambda((depths[1] != null ? depths[1].from : depths[1]), depth0)) != null ? stack1 : "")
     + "\"";
-},"12":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"14":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return " lhead=\"cluster_"
     + ((stack1 = container.lambda((depths[1] != null ? depths[1].to : depths[1]), depth0)) != null ? stack1 : "")
     + "\"";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
-    var stack1, helper, options, buffer = 
-  "digraph \"state transitions\" {\n  splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16\n  fontname=\"Helvetica\" fontsize=12 penwidth=2.0\n  node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]\n  edge [fontname=Helvetica fontsize=10]\n\n"
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=helpers.blockHelperMissing, buffer = 
+  "digraph \"state transitions\" {\n  splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16\n  fontname=\"Helvetica\" fontsize=12 penwidth=2.0\n  ";
+  stack1 = ((helper = (helper = helpers.direction || (depth0 != null ? depth0.direction : depth0)) != null ? helper : alias2),(options={"name":"direction","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  if (!helpers.direction) { stack1 = alias4.call(depth0,stack1,options)}
+  if (stack1 != null) { buffer += stack1; }
+  buffer += "\n  node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]\n  edge [fontname=Helvetica fontsize=10]\n\n"
     + ((stack1 = container.invokePartial(partials["dot.states.template.hbs"],depth0,{"name":"dot.states.template.hbs","data":data,"indent":"  ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "\n";
-  stack1 = ((helper = (helper = helpers.transitions || (depth0 != null ? depth0.transitions : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"transitions","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
-  if (!helpers.transitions) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
+  stack1 = ((helper = (helper = helpers.transitions || (depth0 != null ? depth0.transitions : depth0)) != null ? helper : alias2),(options={"name":"transitions","hash":{},"fn":container.program(3, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  if (!helpers.transitions) { stack1 = alias4.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "}\n";
 },"usePartial":true,"useData":true,"useDepths":true});

--- a/src/render/dot.template.js
+++ b/src/render/dot.template.js
@@ -55,7 +55,7 @@ return templates['dot.template.hbs'] = template({"1":function(container,depth0,h
 
   return "      \"i_"
     + ((stack1 = alias1(depth0, depth0)) != null ? stack1 : "")
-    + "\" [shape=point style=invis margin=0 width=0 height=0]\n      \""
+    + "\" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]\n      \""
     + ((stack1 = alias1((depths[1] != null ? depths[1].from : depths[1]), depth0)) != null ? stack1 : "")
     + "\" -> \"i_"
     + ((stack1 = alias1(depth0, depth0)) != null ? stack1 : "")

--- a/src/render/utl.js
+++ b/src/render/utl.js
@@ -8,7 +8,7 @@ define(function() {
 
     return {
         clone: function (pObject) {
-            return JSON.parse(JSON.stringify(pObject));
+            return Object.assign({}, pObject);
         },
         has: function (pString){
             return function (pObject){

--- a/test/cli/normalizations.spec.js
+++ b/test/cli/normalizations.spec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-// const path   = require('path');
 const expect = require('chai').expect;
 const norm   = require('../../src/cli/normalizations');
 
@@ -12,7 +11,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": undefined,
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -22,7 +22,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": "-",
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -32,7 +33,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": "loopvogel.svg",
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -42,7 +44,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": "loopvogel.svg",
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -52,7 +55,8 @@ describe("#cli - normalize", () => {
             "inputType": "json",
             "outputTo": "loopvogel.svg",
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -70,7 +74,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": "somethingElse.dot",
             "outputType": "json",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -82,7 +87,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": undefined,
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -92,7 +98,8 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": "eidereend.svg",
             "outputType": "svg",
-            "engine": "dot"
+            "engine": "dot",
+            "direction": "top-down"
         });
     });
 
@@ -102,7 +109,19 @@ describe("#cli - normalize", () => {
             "inputType": "smcat",
             "outputTo": "eidereend.svg",
             "outputType": "svg",
-            "engine": "neato"
+            "engine": "neato",
+            "direction": "top-down"
+        });
+    });
+
+    it("accepts and processes the 'direction' paramter", () => {
+        expect(norm.normalize(null, {inputFrom: "eidereend.wak", direction: "left-right"})).to.deep.equal({
+            "inputFrom": "eidereend.wak",
+            "inputType": "smcat",
+            "outputTo": "eidereend.svg",
+            "outputType": "svg",
+            "engine": "dot",
+            "direction": "left-right"
         });
     });
 

--- a/test/cli/validations.spec.js
+++ b/test/cli/validations.spec.js
@@ -55,6 +55,23 @@ describe("#cli - validate", () => {
         });
     });
 
+    describe('#validDirection() - ', () => {
+        it("'left-right' is a valid type", () => {
+            expect(val.validDirection("left-right")).to.equal("left-right");
+        });
+
+        it("'to-the-moon-and-back' is not a valid type", () => {
+            let lFoundError = "";
+
+            try {
+                val.validDirection("to-the-moon-and-back");
+            } catch (e) {
+                lFoundError = e.message;
+            }
+            expect(lFoundError).to.contain("error: 'to-the-moon-and-back' is not a valid direction");
+        });
+    });
+
     describe('#validateArguments() - ', () => {
         it("'-T dot -o kaboeki.dot fixtures/comment-00-single-after-state.smcat is oki", () => {
             try {

--- a/test/parse/fixtures/composite-left-right.dot
+++ b/test/parse/fixtures/composite-left-right.dot
@@ -1,23 +1,23 @@
 digraph "state transitions" {
   splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16
   fontname="Helvetica" fontsize=12 penwidth=2.0
-  
+  rankdir=LR
   node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]
   edge [fontname=Helvetica fontsize=10]
 
     "initial" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 label=""]
-    "a" [label="{a}"]
+    "a" [label="a"]
     "final" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=""]
     subgraph "cluster_b" {
       label="b" style=rounded penwidth=2.0
       "b" [shape=point style=invis margin=0 width=0 height=0]
-        "ba" [label="{ba}"]
-    "bc" [label="{bc}"]
+        "ba" [label="ba"]
+    "bc" [label="bc"]
     subgraph "cluster_bb" {
       label="bb" style=rounded penwidth=2.0
       "bb" [shape=point style=invis margin=0 width=0 height=0]
-        "bba" [label="{bba}"]
-    "bbb" [label="{bbb}"]
+        "bba" [label="bba"]
+    "bbb" [label="bbb"]
   
     }
       "note_ba" [label="ba is really part of b's statemachine\land not of the outer statemachine\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
@@ -33,7 +33,7 @@ digraph "state transitions" {
         subgraph "cluster_caa" {
       label="caa" style=rounded penwidth=2.0
       "caa" [shape=point style=invis margin=0 width=0 height=0]
-        "caaa" [label="{caaa}"]
+        "caaa" [label="caaa"]
   
     }
   

--- a/test/parse/fixtures/composite-left-right.dot
+++ b/test/parse/fixtures/composite-left-right.dot
@@ -10,12 +10,12 @@ digraph "state transitions" {
     "final" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=""]
     subgraph "cluster_b" {
       label="b" style=rounded penwidth=2.0
-      "b" [shape=point style=invis margin=0 width=0 height=0]
+      "b" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "ba" [label="ba"]
     "bc" [label="bc"]
     subgraph "cluster_bb" {
       label="bb" style=rounded penwidth=2.0
-      "bb" [shape=point style=invis margin=0 width=0 height=0]
+      "bb" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "bba" [label="bba"]
     "bbb" [label="bbb"]
   
@@ -26,13 +26,13 @@ digraph "state transitions" {
     }
     subgraph "cluster_c" {
       label="c" style=rounded penwidth=2.0
-      "c" [shape=point style=invis margin=0 width=0 height=0]
+      "c" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         subgraph "cluster_ca" {
       label="ca" style=rounded penwidth=2.0
-      "ca" [shape=point style=invis margin=0 width=0 height=0]
+      "ca" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         subgraph "cluster_caa" {
       label="caa" style=rounded penwidth=2.0
-      "caa" [shape=point style=invis margin=0 width=0 height=0]
+      "caa" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "caaa" [label="caaa"]
   
     }
@@ -45,25 +45,25 @@ digraph "state transitions" {
     "initial" -> "a" [label=" "]
     "a" -> "ba" [label=" "]
     "a" -> "b" [label=" " lhead="cluster_b"]
-      "i_note_tr_a_b_5" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_a_b_5" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "a" -> "i_note_tr_a_b_5" [arrowhead=none]
       "i_note_tr_a_b_5" -> "b" [label=" " lhead="cluster_b"]
       "i_note_tr_a_b_5" -> "note_tr_a_b_5" [style=dashed arrowtail=none arrowhead=none weight=0]
       "note_tr_a_b_5" [label="note for a => b\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
     "a" -> "b" [label="a => b   \l" lhead="cluster_b"]
-      "i_note_tr_a_b_7" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_a_b_7" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "a" -> "i_note_tr_a_b_7" [arrowhead=none]
       "i_note_tr_a_b_7" -> "b" [label="a => b   \l" lhead="cluster_b"]
       "i_note_tr_a_b_7" -> "note_tr_a_b_7" [style=dashed arrowtail=none arrowhead=none weight=0]
       "note_tr_a_b_7" [label="note for caa => final: caa => final\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
     "caa" -> "final" [label=" " ltail="cluster_caa"]
-      "i_note_tr_caa_final_9" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_caa_final_9" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "caa" -> "i_note_tr_caa_final_9" [arrowhead=none ltail="cluster_caa"]
       "i_note_tr_caa_final_9" -> "final" [label=" "]
       "i_note_tr_caa_final_9" -> "note_tr_caa_final_9" [style=dashed arrowtail=none arrowhead=none weight=0]
       "note_tr_caa_final_9" [label="note for caa => final\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
     "caa" -> "final" [label="caa => final   \l" ltail="cluster_caa"]
-      "i_note_tr_caa_final_11" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_caa_final_11" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "caa" -> "i_note_tr_caa_final_11" [arrowhead=none ltail="cluster_caa"]
       "i_note_tr_caa_final_11" -> "final" [label="caa => final   \l"]
       "i_note_tr_caa_final_11" -> "note_tr_caa_final_11" [style=dashed arrowtail=none arrowhead=none weight=0]

--- a/test/parse/fixtures/composite-left-right.json
+++ b/test/parse/fixtures/composite-left-right.json
@@ -1,0 +1,171 @@
+{
+    "direction": "LR",
+    "states": [
+        {
+            "name": "a",
+            "type": "regular"
+        },
+        {
+            "name": "b",
+            "type": "composite",
+            "statemachine": {
+                "states": [
+                    {
+                        "name": "ba",
+                        "type": "regular",
+                        "note": [
+                            "ba is really part of b's statemachine",
+                            "and not of the outer statemachine"
+                        ]
+                    },
+                    {
+                        "name": "bb",
+                        "type": "composite",
+                        "statemachine": {
+                            "states": [
+                                {
+                                    "name": "bba",
+                                    "type": "regular"
+                                },
+                                {
+                                    "name": "bbb",
+                                    "type": "regular"
+                                }
+                            ],
+                            "transitions": [
+                                {
+                                    "from": "bba",
+                                    "to": "bbb"
+                                },
+                                {
+                                    "from": "bbb",
+                                    "to": "bba"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "bc",
+                        "type": "regular"
+                    }
+                ],
+                "transitions": [
+                    {
+                        "from": "ba",
+                        "to": "bb",
+                        "label": "one"
+                    },
+                    {
+                        "from": "ba",
+                        "to": "bc",
+                        "label": "two"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "c",
+            "type": "composite",
+            "statemachine": {
+                "states": [
+                    {
+                        "name": "ca",
+                        "type": "composite",
+                        "statemachine": {
+                            "states": [
+                                {
+                                    "name": "caa",
+                                    "type": "composite",
+                                    "statemachine": {
+                                        "states": [
+                                            {
+                                                "name": "caaa",
+                                                "type": "regular"
+                                            }
+                                        ],
+                                        "transitions": [
+                                            {
+                                                "from": "caaa",
+                                                "to": "final"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "final",
+            "type": "final"
+        },
+        {
+            "name": "initial",
+            "type": "initial"
+        }
+    ],
+    "transitions": [
+        {
+            "from": "a",
+            "to": "caaa"
+        },
+        {
+            "from": "initial",
+            "to": "a"
+        },
+        {
+            "from": "a",
+            "to": "ba"
+        },
+        {
+            "from": "a",
+            "to": "b"
+        },
+        {
+            "from": "a",
+            "to": "b",
+            "note": [
+                "note for a => b"
+            ]
+        },
+        {
+            "from": "a",
+            "to": "b",
+            "label": "a => b"
+        },
+        {
+            "from": "a",
+            "to": "b",
+            "label": "a => b",
+            "note": [
+                "note for caa => final: caa => final"
+            ]
+        },
+        {
+            "from": "caa",
+            "to": "final"
+        },
+        {
+            "from": "caa",
+            "to": "final",
+            "note": [
+                "note for caa => final"
+            ]
+        },
+        {
+            "from": "caa",
+            "to": "final",
+            "label": "caa => final"
+        },
+        {
+            "from": "caa",
+            "to": "final",
+            "label": "caa => final",
+            "note": [
+                "note for caa => final: caa => final"
+            ]
+        }
+    ]
+}

--- a/test/parse/fixtures/composite.dot
+++ b/test/parse/fixtures/composite.dot
@@ -10,12 +10,12 @@ digraph "state transitions" {
     "final" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=""]
     subgraph "cluster_b" {
       label="b" style=rounded penwidth=2.0
-      "b" [shape=point style=invis margin=0 width=0 height=0]
+      "b" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "ba" [label="{ba}"]
     "bc" [label="{bc}"]
     subgraph "cluster_bb" {
       label="bb" style=rounded penwidth=2.0
-      "bb" [shape=point style=invis margin=0 width=0 height=0]
+      "bb" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "bba" [label="{bba}"]
     "bbb" [label="{bbb}"]
   
@@ -26,13 +26,13 @@ digraph "state transitions" {
     }
     subgraph "cluster_c" {
       label="c" style=rounded penwidth=2.0
-      "c" [shape=point style=invis margin=0 width=0 height=0]
+      "c" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         subgraph "cluster_ca" {
       label="ca" style=rounded penwidth=2.0
-      "ca" [shape=point style=invis margin=0 width=0 height=0]
+      "ca" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         subgraph "cluster_caa" {
       label="caa" style=rounded penwidth=2.0
-      "caa" [shape=point style=invis margin=0 width=0 height=0]
+      "caa" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "caaa" [label="{caaa}"]
   
     }
@@ -45,25 +45,25 @@ digraph "state transitions" {
     "initial" -> "a" [label=" "]
     "a" -> "ba" [label=" "]
     "a" -> "b" [label=" " lhead="cluster_b"]
-      "i_note_tr_a_b_5" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_a_b_5" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "a" -> "i_note_tr_a_b_5" [arrowhead=none]
       "i_note_tr_a_b_5" -> "b" [label=" " lhead="cluster_b"]
       "i_note_tr_a_b_5" -> "note_tr_a_b_5" [style=dashed arrowtail=none arrowhead=none weight=0]
       "note_tr_a_b_5" [label="note for a => b\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
     "a" -> "b" [label="a => b   \l" lhead="cluster_b"]
-      "i_note_tr_a_b_7" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_a_b_7" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "a" -> "i_note_tr_a_b_7" [arrowhead=none]
       "i_note_tr_a_b_7" -> "b" [label="a => b   \l" lhead="cluster_b"]
       "i_note_tr_a_b_7" -> "note_tr_a_b_7" [style=dashed arrowtail=none arrowhead=none weight=0]
       "note_tr_a_b_7" [label="note for caa => final: caa => final\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
     "caa" -> "final" [label=" " ltail="cluster_caa"]
-      "i_note_tr_caa_final_9" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_caa_final_9" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "caa" -> "i_note_tr_caa_final_9" [arrowhead=none ltail="cluster_caa"]
       "i_note_tr_caa_final_9" -> "final" [label=" "]
       "i_note_tr_caa_final_9" -> "note_tr_caa_final_9" [style=dashed arrowtail=none arrowhead=none weight=0]
       "note_tr_caa_final_9" [label="note for caa => final\l" shape=note fontsize=10 fillcolor="#ffffcc" penwidth=1.0]
     "caa" -> "final" [label="caa => final   \l" ltail="cluster_caa"]
-      "i_note_tr_caa_final_11" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_caa_final_11" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "caa" -> "i_note_tr_caa_final_11" [arrowhead=none ltail="cluster_caa"]
       "i_note_tr_caa_final_11" -> "final" [label="caa => final   \l"]
       "i_note_tr_caa_final_11" -> "note_tr_caa_final_11" [style=dashed arrowtail=none arrowhead=none weight=0]

--- a/test/parse/fixtures/composite_no_root_transitions.dot
+++ b/test/parse/fixtures/composite_no_root_transitions.dot
@@ -1,6 +1,7 @@
 digraph "state transitions" {
   splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16
   fontname="Helvetica" fontsize=12 penwidth=2.0
+  
   node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]
   edge [fontname=Helvetica fontsize=10]
 

--- a/test/parse/fixtures/composite_no_root_transitions.dot
+++ b/test/parse/fixtures/composite_no_root_transitions.dot
@@ -7,7 +7,7 @@ digraph "state transitions" {
 
     subgraph "cluster_on" {
       label="on" style=rounded penwidth=2.0
-      "on" [shape=point style=invis margin=0 width=0 height=0]
+      "on" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
         "locked" [label="{locked}"]
     "waiting for pin" [label="{waiting for pin}"]
     "unlocked" [label="{unlocked}"]

--- a/test/parse/fixtures/kitchensink.dot
+++ b/test/parse/fixtures/kitchensink.dot
@@ -1,6 +1,7 @@
 digraph "state transitions" {
   splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16
   fontname="Helvetica" fontsize=12 penwidth=2.0
+  
   node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]
   edge [fontname=Helvetica fontsize=10]
 

--- a/test/parse/fixtures/kitchensink.dot
+++ b/test/parse/fixtures/kitchensink.dot
@@ -16,7 +16,7 @@ digraph "state transitions" {
       "final" -> "note_final" [style=dashed arrowtail=none arrowhead=none]
 
     "initial" -> "on backlog" [label="item adds most value   \l"]
-      "i_note_tr_on backlog_doing_2" [shape=point style=invis margin=0 width=0 height=0]
+      "i_note_tr_on backlog_doing_2" [shape=point style=invis margin=0 width=0 height=0 fixedsize=true]
       "on backlog" -> "i_note_tr_on backlog_doing_2" [arrowhead=none]
       "i_note_tr_on backlog_doing_2" -> "doing" [label="working on it   \l"]
       "i_note_tr_on backlog_doing_2" -> "note_tr_on backlog_doing_2" [style=dashed arrowtail=none arrowhead=none weight=0]

--- a/test/parse/fixtures/minimal.dot
+++ b/test/parse/fixtures/minimal.dot
@@ -1,6 +1,7 @@
 digraph "state transitions" {
   splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16
   fontname="Helvetica" fontsize=12 penwidth=2.0
+  
   node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]
   edge [fontname=Helvetica fontsize=10]
 

--- a/test/parse/fixtures/pseudostates.dot
+++ b/test/parse/fixtures/pseudostates.dot
@@ -1,6 +1,7 @@
 digraph "state transitions" {
   splines=true ordering=out compound=true overlap=scale K=0.9 epsilon=0.9 nodesep=0.16
   fontname="Helvetica" fontsize=12 penwidth=2.0
+  
   node [shape=Mrecord style=filled fillcolor=white fontname=Helvetica fontsize=12 penwidth=2.0]
   edge [fontname=Helvetica fontsize=10]
 

--- a/test/parse/fixtures/pseudostates.dot
+++ b/test/parse/fixtures/pseudostates.dot
@@ -9,9 +9,9 @@ digraph "state transitions" {
     "a" [label="{a}"]
     "x" [label="{x}"]
     "y" [label="{y}"]
-    "^" [shape=diamond fixedsize=shape width=0.35 height=0.35 fontsize=10 label=" "]
+    "^" [shape=diamond fixedsize=true width=0.35 height=0.35 fontsize=10 label=" "]
     "^" -> "^" [label="whatcha doing?\l" color=transparent];
-    "]" [shape=rect label=" " fixedsize=shape style=filled fillcolor=black height=0.1]
+    "]" [shape=rect label=" " fixedsize=true style=filled fillcolor=black height=0.1]
     "final" [shape=circle style=filled fillcolor=black fixedsize=true height=0.15 peripheries=2 label=""]
 
     "initial" -> "a" [label=" "]

--- a/test/render/ast2dot.spec.js
+++ b/test/render/ast2dot.spec.js
@@ -14,6 +14,11 @@ const testPairs = [{
     "input": "../parse/fixtures/composite.json",
     "expectedOutput": "../parse/fixtures/composite.dot"
 }, {
+    "title": "renders composite states - left-right",
+    "input": "../parse/fixtures/composite-left-right.json",
+    "options": {direction: "left-right"},
+    "expectedOutput": "../parse/fixtures/composite-left-right.dot"
+}, {
     "title": "renders transitions of composite states even when there's no 'root' transitions",
     "input": "../parse/fixtures/composite_no_root_transitions.json",
     "expectedOutput": "../parse/fixtures/composite_no_root_transitions.dot"
@@ -30,7 +35,7 @@ const testPairs = [{
 describe('#ast2dot', () => {
     testPairs.forEach(pPair => it(pPair.title, () => {
         expect(
-            convert(require(pPair.input))
+            convert(require(pPair.input), pPair.options)
         ).to.equal(
             fs.readFileSync(path.join(__dirname, pPair.expectedOutput), "utf-8")
         );


### PR DESCRIPTION
in addition to top to bottom, which lives on as the default.

- introduces a `--direction` option to the cli and a `direction` option to the API which can take `top-down` (the default and current way of rendering) and `left-right` as values.
- only makes sense on the `dot` output format, so only used there
- also adds a 'direction' option to the sample html (both the fancy looking one and the clunky looking one)