### PR TITLE
doc(types|api): describe how to add a renderer, more strongly type definitions in /types, brush-up of the api doc

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,7 +42,9 @@ Both will dump an svg picture on stdout, which would look like this:
 ## Public API
 ### `render (script, options, callback)`
 The main render function. It parses and renders the _smcat_ `script` you pass
-it, talking any `options` into account and calling `callback` with the results.
+it, talking any `options` into account and either 
+- calling `callback` with the results if a callback was passed, 
+- returning the result (more future proof way to use this function)
 
 #### `script`
 A string containing the script you want to get rendered. This is typically in
@@ -51,7 +53,7 @@ the _smcat_ language (see the
 for details), but you if you pass "json" to the `inputType` option, `render`
 will expect an abstract syntax tree of a state machine.
 
-#### `callback`
+#### `callback` (_depcrecated_)
 A function. When `render` is done it will call this
 function with two parameters:
 - the first will contain `null` if render completed successfully, and an
@@ -137,7 +139,8 @@ and an array of possible values. It'll typically look like this:
         default: "smcat",
         values: [
             {name: "smcat"},
-            {name: "json"}
+            {name: "json"},
+            {name: "scxml"}
         ]
     },
     outputType: {
@@ -148,7 +151,8 @@ and an array of possible values. It'll typically look like this:
             {name: "json"},
             {name: "ast"},
             {name: "svg"},
-            {name: "html"}
+            {name: "html"},
+            {name: "scxml"}
         ]
     },
     engine: {

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,0 +1,54 @@
+# Hacking on state-machine-cat
+
+If you want to change or add to the functionality of state-machine-cat - here's
+some notes that might be of help.
+
+## Adding a new output format ('renderer')
+
+### Render function
+A render function takes a state machine cat AST (that adheres to the state machine cat 
+AST [JSON schema](smcat-ast.schema.json)) and emits a string in the format you desire:
+
+```typescript
+function render (pAST: IStateMachine): string;
+```
+
+### Steps to add it to the api (and command line interface)
+- put the render function in a package under `src/render` (if it's multiple files in their
+  own folder) - or publish your renderer to npm so it can be imported:
+- Require it in `src/render/index.js` and add it to the OUTPUTTYPE2RENDERFUNCTION constant.
+- Add it to the `outputTypes.values` array in `src/options.js`
+- Write tests to make sure the render functions work
+
+### Steps to add it to the website
+The site uses no frameworks - there's just a handlebars template that translates to 
+an index.html and a javascript module that serves as the entry for creating a webpack
+bundle.
+
+- in the handlebars template (`docs/index.hbs`) add a new list item
+```html
+...
+                  <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="YOURRENDERER">
+                          <input type="radio" id="YOURRENDERER" class="mdl-radio__button" name="outputtyperg" value="YOURRENDERER">
+                          <span class="mdl-radio__label">YOURRENDERER</span>
+                        </label>
+                    </span>
+                  </li>
+...
+```
+
+- in `docs/smcat-online-interpreter.js` add event listener next to the other ones
+```javascript
+...
+window.YOURRENDERER.addEventListener("click", updateViewModel('outputType'), false);
+...
+```
+
+- `npm run build` to build the site (webpack to prod and dev; `docs/index.hbs`
+   -> `docs/index.html` and `docs/dev/index.html`). 
+- To test start a simple webserver in the `docs` folder (e.g. with 
+  `python -m SimpleHTTPServer 8481`) and open your webbrowser on http://localhost:8481
+  or http://localhost:8481/dev for the development version (uncompressed bundle with
+  source maps for easy debugging).

--- a/types/state-machine-cat.d.ts
+++ b/types/state-machine-cat.d.ts
@@ -130,7 +130,8 @@ export function getAllowedValues(): IAllowedValues;
 
 export type InputType =
     "smcat" |
-    "json"
+    "json" |
+    "scxml"
 ;
 
 export type OutputType =

--- a/types/state-machine-cat.d.ts
+++ b/types/state-machine-cat.d.ts
@@ -1,3 +1,101 @@
+export type StateType =
+    "regular"     |
+    "initial"     |
+    "final"       |
+    "parallel"    |
+    "choice"      |
+    "fork"        |
+    "forkjoin"    |
+    "history"     |
+    "deephistory" |
+    "join"        |
+    "junction"    |
+    "terminate"
+;
+
+export type ActionTypeType =
+    "activity" |
+    "entry"    |
+    "exit"
+;
+
+export interface IActionType {
+    body: string;
+    type: ActionTypeType;
+}
+
+export interface IState {
+    /**
+     * the name and identifier of the state
+     */
+    name: string;
+    /**
+     * what kind of state (or pseudo state) this state is. E.g. 'regular' 
+     * for normal states or 'initial', 'final', 'choice' etc for pseudo states
+     */
+    type: StateType;
+    /**
+     * the display label of the state. If it's not present, most renderers
+     * will use the states' name in stead
+     */
+    label?: string;
+    actions?: IActionType[];
+    /**
+     * state machine nested within the stated
+     */
+    statemachine?: IStateMachine;
+    active?: boolean;
+    /**
+     * some renderers will use the color attribute to color the state
+     * in their output
+     */
+    color?: string;
+    /**
+     * some renderers will use the note attribute to render a note
+     * (i.e. as a post-it) attached to the stated
+     */
+    note?: string[];
+    /**
+     * convenience, derived attribute - set to true if there's a state
+     * machine inside the state; false in all other cases. For internal
+     * use - @deprecated
+     */
+    isComposite?: boolean;
+    /**
+     * The default parser derives the `type` from the `name` with inband
+     * signaling. The user can override that behavior by explicitly setting
+     * the `type`. This attribute is there to express that (and make sure
+     * that on next parses & processing it doesn't get accidentily 
+     * re-derived from the name again)
+     */
+    typeExplicitlySet?: boolean;
+}
+
+export interface ITransition {
+    /**
+     * reference to the name of the IState the transition is from
+     */
+    from: string;
+    /**
+     * reference to the name of the IState the transition is from
+     */
+    to: string;
+    /**
+     * display label of he transition
+     */
+    label?: string;
+    event?: string;
+    cond?: string;
+    action?: string;
+    note?: string[];
+    color?: string;
+}
+
+export interface IStateMachine {
+    states: IState[];
+    transitions?: ITransition[];
+}
+
 /**
  * The current (semver compliant) version number string of
  * state machine cat
@@ -92,4 +190,4 @@ export interface IRenderOptions {
  * Options: see https://github.com/sverweij/state-machine-cat/docs/api.md
  *
  */
-export function render(pScript: string, pOptions: IRenderOptions): string;
+export function render(pScript: IStateMachine|string, pOptions: IRenderOptions): string;


### PR DESCRIPTION
## Description, Motivation and Context
See title - helps with ease of use and maintenance

## How Has This Been Tested?
- [x] spell checker
- [x] re-reading
- [x] squinting at the text
- [x] manually testing the types with an ide

## Screenshots (if appropriate):

## Types of changes
- [x] &Delta; Documentation

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.