### PR TITLE
bugfix(parse-scxml): improve initial recognition

### DIFF
--- a/src/parse/scxml/normalizeMachine.js
+++ b/src/parse/scxml/normalizeMachine.js
@@ -4,7 +4,8 @@ const arrayify = require('./utl').arrayify;
 
 function normalizeInitialFromObject(pMachine) {
     const lRetval = {
-        id: "initial"
+        // ensure the 'initial' state has a unique name
+        id: pMachine.id ? `${pMachine.id}.initial` : "initial"
     };
     if (pMachine.initial.transition) {
         Object.assign(
@@ -37,9 +38,14 @@ function normalizeInitial(pMachine) {
     let lInitialObject = {};
 
     if (pMachine.initial) {
-        if (pMachine.initial.id) {
+        // => it's an xml node. This detection isn't fool proof...;
+        // if it's a node but it doesn't have a transtion (which
+        // looks like an odd corner case) we won't recognize the
+        // initial
+        // the initial.id shouldn't occur (not allowed in scxml
+        // land), but smcat scxml renderer generates it nonetheless
+        if (pMachine.initial.transition || pMachine.initial.id) {
             lInitialObject = normalizeInitialFromObject(pMachine);
-
         } else {
             lInitialObject = normalizeInitialFromString(pMachine);
         }

--- a/test/parse/scxml.spec.js
+++ b/test/parse/scxml.spec.js
@@ -59,6 +59,78 @@ describe('parse/scxml', () => {
 
     });
 
+    it("Processes an <initial> with a <transition> into an initial state", () => {
+        const SCXML_WITH_INITIAL_NODE = `<?xml version="1.0"?>
+        <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0"> 
+            <initial>
+                <transition target="closed"/>
+            </initial>
+            <state id="closed"/>
+        </scxml>`;
+        const lAST = parser.parse(SCXML_WITH_INITIAL_NODE);
+
+        expect(lAST).to.be.jsonSchema($schema);
+        expect(lAST).to.deep.equal({
+            "states": [
+                {
+                    "name": "initial",
+                    "type": "initial"
+                },
+                {
+                    "name": "closed",
+                    "type": "regular"
+                }
+            ],
+            "transitions": [
+                {
+                    "from": "initial",
+                    "to": "closed"
+                }
+            ]
+        });
+    });
+
+    it("Prefix an initial state within a state with that state's id", () => {
+        const SCXML_WITH_INITIAL_NODE = `<?xml version="1.0"?>
+        <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0"> 
+            <state id="door">
+              <initial>
+                <transition target="closed"/>
+              </initial>
+              <state id="closed"/>
+            </state>
+        </scxml>`;
+        const lAST = parser.parse(SCXML_WITH_INITIAL_NODE);
+
+        expect(lAST).to.be.jsonSchema($schema);
+        expect(lAST).to.deep.equal({
+            "states": [
+                {
+                    "name": "door",
+                    "type": "regular",
+                    "statemachine": {
+                        "states": [
+                            {
+                                "name": "door.initial",
+                                "type": "initial"
+                            },
+                            {
+                                "name": "closed",
+                                "type": "regular"
+                            }
+                        ],
+                        "transitions": [
+                            {
+                                "from": "door.initial",
+                                "to": "closed"
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+    });
+
     it('barfs if the input is invalid xml', () => {
         expect(() => parser.parse('this is no xml')).to.throw("That doesn't look like valid xml");
     });

--- a/test/render/fixtures/510hierarchical-one-initial-state.scxml.re-json
+++ b/test/render/fixtures/510hierarchical-one-initial-state.scxml.re-json
@@ -6,7 +6,7 @@
             "statemachine": {
                 "states": [
                     {
-                        "name": "initial",
+                        "name": "something_nested.initial",
                         "type": "initial"
                     }
                 ]

--- a/test/render/fixtures/514hierarchical-with-initial-state-pointing-somehwhere-with-an-action.scxml.re-json
+++ b/test/render/fixtures/514hierarchical-with-initial-state-pointing-somehwhere-with-an-action.scxml.re-json
@@ -6,7 +6,7 @@
             "statemachine": {
                 "states": [
                     {
-                        "name": "initial",
+                        "name": "something_nested.initial",
                         "type": "initial"
                     },
                     {
@@ -16,7 +16,7 @@
                 ],
                 "transitions": [
                     {
-                        "from": "initial",
+                        "from": "something_nested.initial",
                         "to": "some_state",
                         "action": "here's some executable content",
                         "label": "/ here's some executable content"


### PR DESCRIPTION
## Description, motivation and context
Before this PR the scxml parser didn't recognise the initial state in this scxml - now it does
```xml
<?xml version="1.0" encoding="UTF-8"?>
<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0">
   <initial>
      <transition target="closed" />
   </initial>
   <state id="closed" />
</scxml>
```

## How Has This Been Tested?
- [x] additional unit tests
- [x] automated non-regression tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
