### PR TITLE
feature(cli): automatically classify .scxml and .xml input extensions as scxml

### DIFF
--- a/src/cli/normalize.js
+++ b/src/cli/normalize.js
@@ -4,6 +4,8 @@ const attributesParser = require("./attributes-parser");
 
 const INPUT_EXTENSIONS = {
   ".smcat": "smcat",
+  ".scxml": "scxml",
+  ".xml": "scxml",
   ".json": "json",
   ".ast": "json"
 };

--- a/test/cli/normalize.spec.js
+++ b/test/cli/normalize.spec.js
@@ -176,6 +176,34 @@ describe("#cli - normalize", () => {
     });
   });
 
+  it("classifies the .scxml extension as scxml", () => {
+    expect(normalize("model.scxml")).to.deep.equal({
+      inputFrom: "model.scxml",
+      inputType: "scxml",
+      outputTo: "model.svg",
+      outputType: "svg",
+      engine: "dot",
+      direction: "top-down",
+      dotGraphAttrs: [],
+      dotNodeAttrs: [],
+      dotEdgeAttrs: []
+    });
+  });
+
+  it("classifies the .xml extension as scxml", () => {
+    expect(normalize("model.xml")).to.deep.equal({
+      inputFrom: "model.xml",
+      inputType: "scxml",
+      outputTo: "model.svg",
+      outputType: "svg",
+      engine: "dot",
+      direction: "top-down",
+      dotGraphAttrs: [],
+      dotNodeAttrs: [],
+      dotEdgeAttrs: []
+    });
+  });
+
   it("handles unspecified everything", () => {
     expect(normalize()).to.deep.equal({
       inputFrom: "-",


### PR DESCRIPTION
## Description
See title

## Motivation and Context
Makes use easier

## How Has This Been Tested?
- [x] additional unit test
- [x] automated non-regression tests

## Types of changes
- [x] Feature (non-breaking change which adds functionality)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
