### PR TITLE
ci(gh-actions): set up node modules cache

### DIFF
--- a/.github/workflows/lint-test-linux.yml
+++ b/.github/workflows/lint-test-linux.yml
@@ -1,4 +1,4 @@
-name: CI
+name: install, lint, test - linux
 
 on:
   push:
@@ -16,27 +16,19 @@ jobs:
         node-version: [^8.12, 10.x, 12.x, 13.x]
         platform:
           - ubuntu-latest
-          - macos-latest
-          - windows-latest
-        exclude:
-        - node-version: ^8.12
-          platform: macos-latest
-        - node-version: 10.x
-          platform: macos-latest
-        - node-version: 12.x
-          platform: macos-latest
-        - node-version: ^8.12
-          platform: windows-latest
-        - node-version: 12.x
-          platform: windows-latest
-        - node-version: 13.x
-          platform: windows-latest
 
     runs-on: ${{matrix.platform}}
 
     steps:
     - name: check out
       uses: actions/checkout@v1
+    - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+        restore-keys: |
+          ${{matrix.node-version}}@${{matrix.platform}}-build-
     - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
       uses: actions/setup-node@v1
       with:
@@ -48,10 +40,17 @@ jobs:
       shell: bash
       env:
         CI: true
+    - name: lint
+      run: |
+        node --version
+        npm run lint
+      shell: bash
+      env:
+        CI: true
     - name: lint & test
       run: |
         node --version
-        npm run check
+        npm run test:cover
       shell: bash
       env:
         CI: true

--- a/.github/workflows/lint-test-macos.yml
+++ b/.github/workflows/lint-test-macos.yml
@@ -1,0 +1,49 @@
+name: install, lint, test - macos
+
+on:
+  push:
+      branches:
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  check:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [13.x]
+        platform:
+          - macos-latest
+
+    runs-on: ${{matrix.platform}}
+
+    steps:
+    - name: check out
+      uses: actions/checkout@v1
+    - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+        restore-keys: |
+          ${{matrix.node-version}}@${{matrix.platform}}-build-
+    - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{matrix.node-version}}
+    - name: install
+      run: |
+        node --version
+        npm install
+      shell: bash
+      env:
+        CI: true
+    - name: test coverage
+      run: |
+        node --version
+        npm run test:cover
+      shell: bash
+      env:
+        CI: true

--- a/.github/workflows/lint-test-windows.yml
+++ b/.github/workflows/lint-test-windows.yml
@@ -1,0 +1,49 @@
+name: install, lint, test - windows
+
+on:
+  push:
+      branches:
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  check:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [13.x]
+        platform:
+          - windows-latest
+
+    runs-on: ${{matrix.platform}}
+
+    steps:
+    - name: check out
+      uses: actions/checkout@v1
+    - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+        restore-keys: |
+          ${{matrix.node-version}}@${{matrix.platform}}-build-
+    - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{matrix.node-version}}
+    - name: install
+      run: |
+        node --version
+        npm install
+      shell: bash
+      env:
+        CI: true
+    - name: test coverage
+      run: |
+        node --version
+        npm run test:cover
+      shell: bash
+      env:
+        CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: node_js
 
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"


### PR DESCRIPTION
## Description, motivation & context
- see title - because it makes builds faster
- split off macOS & windows builds in separate workflows so they're easier to restart individually.
- on travis don't run node 8 anymore


## How Has This Been Tested?
By making this PR and doing several pushes to it


## Types of changes
- [x] other: ci tweaks

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
