### PR TITLE
bugfix(doc): deprecate xmi as an output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ working state machines using a tool that eats
 [XMI](https://en.wikipedia.org/wiki/XML_Metadata_Interchange) and emits code
 you can do just that - read more in [State Machine Cat and XMI](./docs/XMI.md)
 
-> &tritime; The XMI export feature was experimental and will be removed in a future version.
+> &tritime; The XMI export feature is _deprecated_ and will be removed with
+> the next major release.
 
 ### Programmatically
 

--- a/docs/XMI.md
+++ b/docs/XMI.md
@@ -2,14 +2,14 @@
 
 > :rotating_light: XMI support in state machine cat is **deprecated**. It will be removed
 > in the next major release - which will probably coincide with the introduction of node 14.
-> 
+>
 > #### Why deprecate XMI support?
+>
 > XMI is a gnarly format which takes a lot of effort to do well. I don't use it, and the
 > use in other contexts eludes me. On top each suppliers implements a different flavor,
-> so xmi created with one tool will look like something hit by a truck in another (if 
+> so xmi created with one tool will look like something hit by a truck in another (if
 > it works at all).
 >
-> 
 > (If you read this, do see a use for xmi support in state-machine-cat _and_ are willing to
 > take up maintenance - please get in touch).
 >

--- a/docs/XMI.md
+++ b/docs/XMI.md
@@ -1,13 +1,20 @@
 # State Machine Cat and XMI (deprecated)
 
 > :rotating_light: XMI support in state machine cat is **deprecated**. It will be removed
-> in the next major release - which will probably coincide with the release of Node 14.
-> XMI is a gnarly format which takes a lot of effort to do well, with little or no return.
-> On top of that it has many tastes between suppliers, so xmi created with one
-> tool will not work or look like something a truck rode over in another.
+> in the next major release - which will probably coincide with the introduction of node 14.
+> 
+> #### Why deprecate XMI support?
+> XMI is a gnarly format which takes a lot of effort to do well. I don't use it, and the
+> use in other contexts eludes me. On top each suppliers implements a different flavor,
+> so xmi created with one tool will look like something hit by a truck in another (if 
+> it works at all).
 >
-> If you want to interchange state machines with a well defined standard - please have a
-> look at state-machine-cat's [SCXML](./SCXML.md) support.
+> 
+> (If you read this, do see a use for xmi support in state-machine-cat _and_ are willing to
+> take up maintenance - please get in touch).
+>
+> In the mean time I encourage you to look into [SCXML](./SCXML.md) - which
+> is a well defined standard state-machine-cat supports quite well.
 
 XML Metadata Interchange is a [OMG standard](https://www.omg.org/spec/XMI) that
 aims to be a format that enables tools to exchange models with each other. It's

--- a/docs/XMI.md
+++ b/docs/XMI.md
@@ -1,4 +1,13 @@
-# State Machine Cat and XMI
+# State Machine Cat and XMI (deprecated)
+
+> :rotating_light: XMI support in state machine cat is **deprecated**. It will be removed
+> in the next major release - which will probably coincide with the release of Node 14.
+> XMI is a gnarly format which takes a lot of effort to do well, with little or no return.
+> On top of that it has many tastes between suppliers, so xmi created with one
+> tool will not work or look like something a truck rode over in another.
+>
+> If you want to interchange state machines with a well defined standard - please have a
+> look at state-machine-cat's [SCXML](./SCXML.md) support.
 
 XML Metadata Interchange is a [OMG standard](https://www.omg.org/spec/XMI) that
 aims to be a format that enables tools to exchange models with each other. It's

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -161,7 +161,7 @@
             <span class="mdl-list__item-primary-content">
               <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="xmi">
                 <input type="radio" id="xmi" class="mdl-radio__button" name="outputtyperg" value="xmi">
-                <span class="mdl-radio__label">XMI <em>(experimental)</em></span>
+                <span class="mdl-radio__label" style="color:gray">XMI <em>(deprecated)</em></span>
               </label>
             </span>
           </li>

--- a/docs/index.hbs
+++ b/docs/index.hbs
@@ -169,7 +169,7 @@
             <span class="mdl-list__item-primary-content">
               <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="xmi">
                 <input type="radio" id="xmi" class="mdl-radio__button" name="outputtyperg" value="xmi">
-                <span class="mdl-radio__label">XMI <em>(experimental)</em></span>
+                <span class="mdl-radio__label" style="color:gray">XMI <em>(deprecated)</em></span>
               </label>
             </span>
           </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
             <span class="mdl-list__item-primary-content">
               <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="xmi">
                 <input type="radio" id="xmi" class="mdl-radio__button" name="outputtyperg" value="xmi">
-                <span class="mdl-radio__label">XMI <em>(experimental)</em></span>
+                <span class="mdl-radio__label" style="color:gray">XMI <em>(deprecated)</em></span>
               </label>
             </span>
           </li>


### PR DESCRIPTION
## Motivation and Context
As explained in XMI.md

> XMI is a gnarly format which takes a lot of effort to do well, with little or no return.
> On top of that it has many tastes between suppliers, so xmi created with one
> tool will not work or look like something a truck rode over in another.
>
> If you want to interchange state machines with a well defined standard - please have a
> look at state-machine-cat's [SCXML](./SCXML.md) support.

## How Has This Been Tested?
- eyeballs (no code was harmed in the making if this PR)
- [x] non-regression tests + green CI


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code I add will be subject to [The MIT license](../LICENSE), and I'm OK with that.
- [x] The code I've added is my own original work.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
