### PR TITLE
bugfix(parse): properly output parsed escaped quotes

### DIFF
--- a/.github/workflows/lint-test-linux.yml
+++ b/.github/workflows/lint-test-linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x, 14.x]
         platform:
           - ubuntu-latest
 

--- a/.github/workflows/lint-test-macos.yml
+++ b/.github/workflows/lint-test-macos.yml
@@ -2,48 +2,47 @@ name: install, lint, test - macos
 
 on:
   push:
-      branches:
+    branches:
       - master
       - develop
   pull_request:
 
 jobs:
   check:
-
     strategy:
       fail-fast: false
       matrix:
-        node-version: [13.x]
+        node-version: [14.x]
         platform:
           - macos-latest
 
     runs-on: ${{matrix.platform}}
 
     steps:
-    - name: check out
-      uses: actions/checkout@v1
-    - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
-        restore-keys: |
-          ${{matrix.node-version}}@${{matrix.platform}}-build-
-    - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{matrix.node-version}}
-    - name: install
-      run: |
-        node --version
-        npm install
-      shell: bash
-      env:
-        CI: true
-    - name: test coverage
-      run: |
-        node --version
-        npm run test:cover
-      shell: bash
-      env:
-        CI: true
+      - name: check out
+        uses: actions/checkout@v1
+      - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+          restore-keys: |
+            ${{matrix.node-version}}@${{matrix.platform}}-build-
+      - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.node-version}}
+      - name: install
+        run: |
+          node --version
+          npm install
+        shell: bash
+        env:
+          CI: true
+      - name: test coverage
+        run: |
+          node --version
+          npm run test:cover
+        shell: bash
+        env:
+          CI: true

--- a/.github/workflows/lint-test-windows.yml
+++ b/.github/workflows/lint-test-windows.yml
@@ -2,48 +2,47 @@ name: install, lint, test - windows
 
 on:
   push:
-      branches:
+    branches:
       - master
       - develop
   pull_request:
 
 jobs:
   check:
-
     strategy:
       fail-fast: false
       matrix:
-        node-version: [13.x]
+        node-version: [14.x]
         platform:
           - windows-latest
 
     runs-on: ${{matrix.platform}}
 
     steps:
-    - name: check out
-      uses: actions/checkout@v1
-    - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
-        restore-keys: |
-          ${{matrix.node-version}}@${{matrix.platform}}-build-
-    - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{matrix.node-version}}
-    - name: install
-      run: |
-        node --version
-        npm install
-      shell: bash
-      env:
-        CI: true
-    - name: test coverage
-      run: |
-        node --version
-        npm run test:cover
-      shell: bash
-      env:
-        CI: true
+      - name: check out
+        uses: actions/checkout@v1
+      - name: cache node modules for ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package.json')}}
+          restore-keys: |
+            ${{matrix.node-version}}@${{matrix.platform}}-build-
+      - name: set up node ${{matrix.node-version}}@${{matrix.platform}}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.node-version}}
+      - name: install
+        run: |
+          node --version
+          npm install
+        shell: bash
+        env:
+          CI: true
+      - name: test coverage
+        run: |
+          node --version
+          npm run test:cover
+        shell: bash
+        env:
+          CI: true

--- a/src/parse/smcat/peg/smcat-parser.pegjs
+++ b/src/parse/smcat/peg/smcat-parser.pegjs
@@ -211,7 +211,7 @@ string
     / unquotedstring
 
 quotedstring "double quoted string"
-    = '"' s:stringcontent '"' {return s.join("")}
+    = '"' s:stringcontent '"' {return s.join("").replace(/\\\"/g, "\"")}
 
 stringcontent
     = (!'"' c:('\\"'/ .) {return c})*

--- a/src/parse/smcat/smcat-parser.js
+++ b/src/parse/smcat/smcat-parser.js
@@ -319,7 +319,7 @@ function peg$parse(input, options) {
       peg$c112 = peg$otherExpectation("double quoted string"),
       peg$c113 = "\"",
       peg$c114 = peg$literalExpectation("\"", false),
-      peg$c115 = function(s) {return s.join("")},
+      peg$c115 = function(s) {return s.join("").replace(/\\\"/g, "\"")},
       peg$c116 = "\\\"",
       peg$c117 = peg$literalExpectation("\\\"", false),
       peg$c118 = peg$anyExpectation(),

--- a/test/parse/01-transitions-only.json
+++ b/test/parse/01-transitions-only.json
@@ -66,6 +66,32 @@
     }
   },
   {
+    "title": "transitions without entity declarations: 2 entities with a label and quoted arguments",
+    "program": "a => b: event[condition]/ action(\"with arguments\");",
+    "ast": {
+      "states": [
+        {
+          "name": "a",
+          "type": "regular"
+        },
+        {
+          "name": "b",
+          "type": "regular"
+        }
+      ],
+      "transitions": [
+        {
+          "from": "a",
+          "to": "b",
+          "label": "event[condition]/ action(\"with arguments\")",
+          "event": "event",
+          "cond": "condition",
+          "action": "action(\"with arguments\")"
+        }
+      ]
+    }
+  },
+  {
     "title": "transitions without entity declarations: 2 entities with a label that needs quotes",
     "program": "a => b: \"if you want to ; use a semicolon; put quotes around the label\";",
     "ast": {


### PR DESCRIPTION
## Description

Escaped quotes (`"\""`) were output in the parse tree as `"\\\""`, which caused #121. This PR fixes that.

## Motivation and Context

fixes #121 

## How Has This Been Tested?

- [x] additional unit test
- [x] automated non-regression tests
- [x] green ci
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
