### PR TITLE
feature(render): adds encapsulated postscript (eps) output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Usage: smcat [options] [infile]
 
 Options:
   -V, --version               output the version number
-  -T --output-type <type>     svg|ps|ps2|dot|smcat|json|ast|scxml|oldsvg|scjson (default: "svg")
+  -T --output-type <type>     svg|eps|ps|ps2|dot|smcat|json|ast|scxml|oldsvg|scjson (default: "svg")
   -I --input-type <type>      smcat|json|scxml (default: "smcat")
   -E --engine <type>          dot|circo|fdp|neato|osage|twopi (default: "dot")
   -d --direction <dir>        top-down|bottom-top|left-right|right-left (default: "top-down")

--- a/src/cli/normalize.js
+++ b/src/cli/normalize.js
@@ -18,6 +18,9 @@ const OUTPUT_EXTENSIONS = {
   ".scjson": "scjson",
   ".scxml": "scxml",
   ".svg": "svg",
+  ".ps": "ps",
+  ".ps2": "ps2",
+  ".eps": "eps",
 };
 
 /**
@@ -43,6 +46,7 @@ function outputType2Extension(pOutputType) {
   const lExceptions = {
     oldsvg: "svg",
     oldps2: "ps",
+    oldeps: "eps",
     ps2: "ps",
   };
   return lExceptions[pOutputType] || pOutputType;

--- a/src/options.js
+++ b/src/options.js
@@ -9,6 +9,7 @@ const ALLOWED_VALUES = Object.freeze({
     default: "svg",
     values: [
       { name: "svg" },
+      { name: "eps" },
       { name: "ps" },
       { name: "ps2" },
       { name: "dot" },
@@ -18,6 +19,7 @@ const ALLOWED_VALUES = Object.freeze({
       { name: "scxml" },
       { name: "oldsvg" },
       { name: "oldps2" },
+      { name: "oldeps" },
       { name: "scjson" },
     ],
   },

--- a/src/render/index-node.js
+++ b/src/render/index-node.js
@@ -12,10 +12,12 @@ module.exports = function getRenderFunction(pOutputType) {
     smcat,
     dot,
     svg: vector,
+    eps: vector,
     ps: vector,
     ps2: vector,
     oldsvg: oldVector,
     oldps2: oldVector,
+    oldeps: oldVector,
     scjson,
     scxml,
   };

--- a/src/render/vector/vector-with-viz-js.js
+++ b/src/render/vector/vector-with-viz-js.js
@@ -5,6 +5,7 @@ const ast2dot = require("../dot");
 const OUTPUT_TYPE2FORMAT = {
   oldsvg: "svg",
   oldps2: "ps2",
+  oldeps: "eps",
 };
 
 module.exports = (pAST, pOptions) =>

--- a/test/render/fixtures/000empty.eps
+++ b/test/render/fixtures/000empty.eps
@@ -1,0 +1,195 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 44 44
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 44 44
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 8 8 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/100one-state.eps
+++ b/test/render/fixtures/100one-state.eps
@@ -1,0 +1,214 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 100 80
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 100 80
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 64 44 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/101one-state-with-activities.eps
+++ b/test/render/fixtures/101one-state-with-activities.eps
@@ -1,0 +1,231 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 134 90
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 134 90
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 98 54 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+41.6646 29.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+5.6646 9.2 moveto 78.6708 (some activities) alignedtext
+0 0 0 nodecolor
+newpath 0 23 moveto
+0 23 lineto
+90 23 lineto
+90 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 0 23 moveto
+0 23 lineto
+90 23 lineto
+90 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 77 1 77 1 curveto
+83 1 89 7 89 13 curveto
+89 13 89 33 89 33 curveto
+89 39 83 45 77 45 curveto
+77 45 13 45 13 45 curveto
+7 45 1 39 1 33 curveto
+1 33 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/102one-state-with-onentry.eps
+++ b/test/render/fixtures/102one-state-with-onentry.eps
@@ -1,0 +1,231 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 219 90
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 219 90
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 183 54 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+84.6646 29.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.334 9.2 moveto 163.332 (entry/ console.log\('hello there'\)) alignedtext
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+175.5 23 lineto
+175.5 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+175.5 23 lineto
+175.5 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 162 1 162 1 curveto
+168 1 174 7 174 13 curveto
+174 13 174 33 174 33 curveto
+174 39 168 45 162 45 curveto
+162 45 13 45 13 45 curveto
+7 45 1 39 1 33 curveto
+1 33 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/103one-state-with-onentries.eps
+++ b/test/render/fixtures/103one-state-with-onentries.eps
@@ -1,0 +1,234 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 219 110
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 219 110
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 183 74 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+84.6646 49.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.334 29.2 moveto 163.332 (entry/ console.log\('hello there'\)) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.5 9.2 moveto 112.6692 (entry/ callThePolice\(\)) alignedtext
+0 0 0 nodecolor
+newpath .5 43 moveto
+.5 43 lineto
+175.5 43 lineto
+175.5 43 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath .5 43 moveto
+.5 43 lineto
+175.5 43 lineto
+175.5 43 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 162 1 162 1 curveto
+168 1 174 7 174 13 curveto
+174 13 174 53 174 53 curveto
+174 59 168 65 162 65 curveto
+162 65 13 65 13 65 curveto
+7 65 1 59 1 53 curveto
+1 53 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/104one-state-with-onexit.eps
+++ b/test/render/fixtures/104one-state-with-onexit.eps
@@ -1,0 +1,231 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 177 90
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 177 90
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 141 54 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+63.6646 29.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.0046 9.2 moveto 121.9908 (exit/ console.log\('bye!'\)) alignedtext
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+133.5 23 lineto
+133.5 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+133.5 23 lineto
+133.5 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 120 1 120 1 curveto
+126 1 132 7 132 13 curveto
+132 13 132 33 132 33 curveto
+132 39 126 45 120 45 curveto
+120 45 13 45 13 45 curveto
+7 45 1 39 1 33 curveto
+1 33 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/105one-state-with-onexits.eps
+++ b/test/render/fixtures/105one-state-with-onexits.eps
@@ -1,0 +1,234 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 177 110
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 177 110
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 141 74 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+63.6646 49.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.0046 29.2 moveto 121.9908 (exit/ console.log\('bye!'\)) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.5 9.2 moveto 104.0088 (exit/ doTheDishes\(\)) alignedtext
+0 0 0 nodecolor
+newpath .5 43 moveto
+.5 43 lineto
+133.5 43 lineto
+133.5 43 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath .5 43 moveto
+.5 43 lineto
+133.5 43 lineto
+133.5 43 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 120 1 120 1 curveto
+126 1 132 7 132 13 curveto
+132 13 132 53 132 53 curveto
+132 59 126 65 120 65 curveto
+120 65 13 65 13 65 curveto
+7 65 1 59 1 53 curveto
+1 53 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/106one-state-with-activities-needing-escapes.eps
+++ b/test/render/fixtures/106one-state-with-activities-needing-escapes.eps
@@ -1,0 +1,231 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 100 90
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 100 90
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 64 54 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 29.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6 9.2 moveto 36.3528 ([<]asdf) alignedtext
+0 0 0 nodecolor
+newpath 0 23 moveto
+0 23 lineto
+56 23 lineto
+56 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 0 23 moveto
+0 23 lineto
+56 23 lineto
+56 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 43 1 43 1 curveto
+49 1 55 7 55 13 curveto
+55 13 55 33 55 33 curveto
+55 39 49 45 43 45 curveto
+43 45 13 45 13 45 curveto
+7 45 1 39 1 33 curveto
+1 33 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/110one-initial-state.eps
+++ b/test/render/fixtures/110one-initial-state.eps
@@ -1,0 +1,204 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 55 55
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 55 55
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 19 19 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% initial
+gsave
+0 0 0 nodecolor
+5.5 5.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+5.5 5.5 5.5 5.5 ellipse_path stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/111initial-state-pointing-somehwhere.eps
+++ b/test/render/fixtures/111initial-state-pointing-somehwhere.eps
@@ -1,0 +1,246 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 124 119
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 124 119
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 88 83 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% initial
+gsave
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+10.6588 14.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 67.6667 1 67.6667 1 curveto
+73.3333 1 79 6.6667 79 12.3333 curveto
+79 12.3333 79 23.6667 79 23.6667 curveto
+79 29.3333 73.3333 35 67.6667 35 curveto
+67.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 40 63.9886 moveto
+40 59.6293 40 53.1793 40 46.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+40 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/112initial-state-pointing-somehwhere-with-an-event.eps
+++ b/test/render/fixtures/112initial-state-pointing-somehwhere-with-an-event.eps
@@ -1,0 +1,246 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 176 119
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 176 119
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 140 83 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% initial
+gsave
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+10.6588 14.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 67.6667 1 67.6667 1 curveto
+73.3333 1 79 6.6667 79 12.3333 curveto
+79 12.3333 79 23.6667 79 23.6667 curveto
+79 29.3333 73.3333 35 67.6667 35 curveto
+67.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 40 63.9886 moveto
+40 59.6293 40 53.1793 40 46.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+40 47 moveto 92.253 (an awesome event   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/113initial-state-pointing-somehwhere-with-a-condition.eps
+++ b/test/render/fixtures/113initial-state-pointing-somehwhere-with-a-condition.eps
@@ -1,0 +1,246 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 124 119
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 124 119
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 88 83 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% initial
+gsave
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+10.6588 14.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 67.6667 1 67.6667 1 curveto
+73.3333 1 79 6.6667 79 12.3333 curveto
+79 12.3333 79 23.6667 79 23.6667 curveto
+79 29.3333 73.3333 35 67.6667 35 curveto
+67.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 40 63.9886 moveto
+40 59.6293 40 53.1793 40 46.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+40 47 moveto 29.454 ([yes]   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/114initial-state-pointing-somehwhere-with-an-action.eps
+++ b/test/render/fixtures/114initial-state-pointing-somehwhere-with-an-action.eps
@@ -1,0 +1,246 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 239 119
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 239 119
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 203 83 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% initial
+gsave
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+40 69.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+10.6588 14.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 67.6667 1 67.6667 1 curveto
+73.3333 1 79 6.6667 79 12.3333 curveto
+79 12.3333 79 23.6667 79 23.6667 curveto
+79 29.3333 73.3333 35 67.6667 35 curveto
+67.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 40 63.9886 moveto
+40 59.6293 40 53.1793 40 46.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 43.5001 46.0122 moveto
+40 36.0122 lineto
+36.5001 46.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+40 47 moveto 155.04 (/ here's some executable content   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/120one-final-state.eps
+++ b/test/render/fixtures/120one-final-state.eps
@@ -1,0 +1,208 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 63 63
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 63 63
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 27 27 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% final
+gsave
+0 0 0 nodecolor
+9.5 9.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+9.5 9.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+9.5 9.5 9.5 9.5 ellipse_path stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/130one-history-state.eps
+++ b/test/render/fixtures/130one-history-state.eps
@@ -1,0 +1,205 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 80 80
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 80 80
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 44 44 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% machine.history
+gsave
+2 setlinewidth
+filled
+0 0 0 nodecolor
+18 18 18 18 ellipse_path stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+13.6686 14.4 moveto 8.6628 (H) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/131one-deep-history-state.eps
+++ b/test/render/fixtures/131one-deep-history-state.eps
@@ -1,0 +1,224 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 136 143
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 136 143
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 100 107 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_machine
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 72 8 72 8 curveto
+78 8 84 14 84 20 curveto
+84 20 84 79.4656 84 79.4656 curveto
+84 85.4656 78 91.4656 72 91.4656 curveto
+72 91.4656 20 91.4656 20 91.4656 curveto
+14 91.4656 8 85.4656 8 79.4656 curveto
+8 79.4656 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+23.8296 72.6656 moveto 45.3408 (machine) alignedtext
+grestore
+% machine
+% machine deep history
+gsave
+2 setlinewidth
+filled
+0 0 0 nodecolor
+35 34.7328 18.9685 18.9685 ellipse_path stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+28.3352 31.1328 moveto 13.3296 (H*) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/200more-states.eps
+++ b/test/render/fixtures/200more-states.eps
@@ -1,0 +1,299 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 401 90
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 401 90
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 365 54 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+37.6646 29.2 moveto 6.6708 (a) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.3314 9.2 moveto 69.3372 (some activity) alignedtext
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+81.5 23 lineto
+81.5 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+81.5 23 lineto
+81.5 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 68 1 68 1 curveto
+74 1 80 7 80 13 curveto
+80 13 80 33 80 33 curveto
+80 39 74 45 68 45 curveto
+68 45 13 45 13 45 curveto
+7 45 1 39 1 33 curveto
+1 33 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+% the b state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+114.486 19.2 moveto 56.028 (the b state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 115.8333 6 moveto
+115.8333 6 169.1667 6 169.1667 6 curveto
+174.8333 6 180.5 11.6667 180.5 17.3333 curveto
+180.5 17.3333 180.5 28.6667 180.5 28.6667 curveto
+180.5 34.3333 174.8333 40 169.1667 40 curveto
+169.1667 40 115.8333 40 115.8333 40 curveto
+110.1667 40 104.5 34.3333 104.5 28.6667 curveto
+104.5 28.6667 104.5 17.3333 104.5 17.3333 curveto
+104.5 11.6667 110.1667 6 115.8333 6 curveto
+stroke
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+256.5 29.2 moveto 6 (c) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+209.4876 9.2 moveto 100.0248 (yet another activity) alignedtext
+0 0 0 nodecolor
+newpath 203.5 23 moveto
+203.5 23 lineto
+315.5 23 lineto
+315.5 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 203.5 23 moveto
+203.5 23 lineto
+315.5 23 lineto
+315.5 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 216.5 1 moveto
+216.5 1 302.5 1 302.5 1 curveto
+308.5 1 314.5 7 314.5 13 curveto
+314.5 13 314.5 33 314.5 33 curveto
+314.5 39 308.5 45 302.5 45 curveto
+302.5 45 216.5 45 216.5 45 curveto
+210.5 45 204.5 39 204.5 33 curveto
+204.5 33 204.5 13 204.5 13 curveto
+204.5 7 210.5 1 216.5 1 curveto
+stroke
+grestore
+% final
+gsave
+0 0 0 nodecolor
+347.5 23 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+347.5 23 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+347.5 23 9.5 9.5 ellipse_path stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/300non-hierarchic-transition-no-event.eps
+++ b/test/render/fixtures/300non-hierarchic-transition-no-event.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 100 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 100 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 64 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/301non-hierarchic-transition-with-event.eps
+++ b/test/render/fixtures/301non-hierarchic-transition-with-event.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 132 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 132 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 96 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 60.019 (some event   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/302non-hierarchic-transitions-with-event.eps
+++ b/test/render/fixtures/302non-hierarchic-transitions-with-event.eps
@@ -1,0 +1,340 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 301 191
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 301 191
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 265 155 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+87.5885 125.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 75.2572 112 moveto
+75.2572 112 106.5905 112 106.5905 112 curveto
+112.2572 112 117.9239 117.6667 117.9239 123.3333 curveto
+117.9239 123.3333 117.9239 134.6667 117.9239 134.6667 curveto
+117.9239 140.3333 112.2572 146 106.5905 146 curveto
+106.5905 146 75.2572 146 75.2572 146 curveto
+69.5905 146 63.9239 140.3333 63.9239 134.6667 curveto
+63.9239 134.6667 63.9239 123.3333 63.9239 123.3333 curveto
+63.9239 117.6667 69.5905 112 75.2572 112 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+87.5885 61.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 75.2572 48 moveto
+75.2572 48 106.5905 48 106.5905 48 curveto
+112.2572 48 117.9239 53.6667 117.9239 59.3333 curveto
+117.9239 59.3333 117.9239 70.6667 117.9239 70.6667 curveto
+117.9239 76.3333 112.2572 82 106.5905 82 curveto
+106.5905 82 75.2572 82 75.2572 82 curveto
+69.5905 82 63.9239 76.3333 63.9239 70.6667 curveto
+63.9239 70.6667 63.9239 59.3333 63.9239 59.3333 curveto
+63.9239 53.6667 69.5905 48 75.2572 48 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 62.6043 124.2843 moveto
+40.0137 119.8772 11.0163 112.5468 3.9049 103 curveto
+-11.1148 82.8366 22.649 73.2109 52.3998 68.7236 curveto
+stroke
+0 0 0 edgecolor
+newpath 53.2251 72.1442 moveto
+62.6691 67.3419 lineto
+52.2916 65.2067 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 53.2251 72.1442 moveto
+62.6691 67.3419 lineto
+52.2916 65.2067 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+3.9239 94 moveto 60.019 (some event   ) alignedtext
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 90.9239 110.8314 moveto
+90.9239 105.4728 90.9239 99.4735 90.9239 93.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 94.424 93.4363 moveto
+90.9239 83.4363 lineto
+87.424 93.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 94.424 93.4363 moveto
+90.9239 83.4363 lineto
+87.424 93.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+90.9239 94 moveto 85.583 (some other event   ) alignedtext
+grestore
+% b->a
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 119.1725 67.3431 moveto
+150.5457 71.09 194.7107 80.4628 177.9239 103 curveto
+171.814 111.2029 149.5441 117.7703 129.067 122.2526 curveto
+stroke
+0 0 0 edgecolor
+newpath 128.3222 118.8324 moveto
+119.2373 124.2835 lineto
+129.7387 125.6876 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 128.3222 118.8324 moveto
+119.2373 124.2835 lineto
+129.7387 125.6876 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+180.9239 94 moveto 76.145 (and back again   ) alignedtext
+grestore
+% final
+gsave
+0 0 0 nodecolor
+90.9239 9.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+90.9239 9.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+90.9239 9.5 9.5 9.5 ellipse_path stroke
+grestore
+% b->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 90.9239 46.8272 moveto
+90.9239 41.202 90.9239 34.9783 90.9239 29.2515 curveto
+stroke
+0 0 0 edgecolor
+newpath 94.424 29.1396 moveto
+90.9239 19.1396 lineto
+87.424 29.1397 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 94.424 29.1396 moveto
+90.9239 19.1396 lineto
+87.424 29.1397 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+90.9239 30 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/303non-hierarchic-transition-with-condition.eps
+++ b/test/render/fixtures/303non-hierarchic-transition-with-condition.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 153 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 153 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 117 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 81.133 ([some condition]   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/304non-hierarchic-transition-with-action.eps
+++ b/test/render/fixtures/304non-hierarchic-transition-with-action.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 137 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 137 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 101 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 65.017 (/some action   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/305non-hierarchic-transition-with-event-and-condtion.eps
+++ b/test/render/fixtures/305non-hierarchic-transition-with-event-and-condtion.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 189 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 189 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 153 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 116.706 (some event [a condition]   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/306non-hierarchic-transition-with-event-and-action.eps
+++ b/test/render/fixtures/306non-hierarchic-transition-with-event-and-action.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 239 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 239 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 203 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 166.717 (some event / an action of some sort   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/307non-hierarchic-transition-with-event-action-and-condtion.eps
+++ b/test/render/fixtures/307non-hierarchic-transition-with-event-action-and-condtion.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 301 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 301 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 265 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 228.962 (some event [ a condition ] / an action of some sort   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/308non-hierarchic-transtion-with-condition-and-action.eps
+++ b/test/render/fixtures/308non-hierarchic-transtion-with-condition-and-action.eps
@@ -1,0 +1,256 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 307 144
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 307 144
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 271 108 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 78.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 65 moveto
+12.3333 65 43.6667 65 43.6667 65 curveto
+49.3333 65 55 70.6667 55 76.3333 curveto
+55 76.3333 55 87.6667 55 87.6667 curveto
+55 93.3333 49.3333 99 43.6667 99 curveto
+43.6667 99 12.3333 99 12.3333 99 curveto
+6.6667 99 1 93.3333 1 87.6667 curveto
+1 87.6667 1 76.3333 1 76.3333 curveto
+1 70.6667 6.6667 65 12.3333 65 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 63.8314 moveto
+28 58.4728 28 52.4735 28 46.6262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 46.4363 moveto
+28 36.4363 lineto
+24.5001 46.4363 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 47 moveto 234.934 ([some condition]/ "here's some executable content"   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/400pseudo-state-forkjoin-explicit.eps
+++ b/test/render/fixtures/400pseudo-state-forkjoin-explicit.eps
@@ -1,0 +1,341 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 179
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 179
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 143 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 113.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 100 moveto
+12.3333 100 43.6667 100 43.6667 100 curveto
+49.3333 100 55 105.6667 55 111.3333 curveto
+55 111.3333 55 122.6667 55 122.6667 curveto
+55 128.3333 49.3333 134 43.6667 134 curveto
+43.6667 134 12.3333 134 12.3333 134 curveto
+6.6667 134 1 128.3333 1 122.6667 curveto
+1 122.6667 1 111.3333 1 111.3333 curveto
+1 105.6667 6.6667 100 12.3333 100 curveto
+stroke
+grestore
+% ]
+gsave
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+65.3326 63.9 moveto 3.3348 ( ) alignedtext
+grestore
+% a->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 42.3007 98.8491 moveto
+47.4258 92.3442 53.0678 85.1832 57.664 79.3495 curveto
+stroke
+0 0 0 edgecolor
+newpath 60.6967 81.1558 moveto
+64.1362 71.1348 lineto
+55.1982 76.8237 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 60.6967 81.1558 moveto
+64.1362 71.1348 lineto
+55.1982 76.8237 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 82 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+102.6646 113.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 100 moveto
+90.3333 100 121.6667 100 121.6667 100 curveto
+127.3333 100 133 105.6667 133 111.3333 curveto
+133 111.3333 133 122.6667 133 122.6667 curveto
+133 128.3333 127.3333 134 121.6667 134 curveto
+121.6667 134 90.3333 134 90.3333 134 curveto
+84.6667 134 79 128.3333 79 122.6667 curveto
+79 122.6667 79 111.3333 79 111.3333 curveto
+79 105.6667 84.6667 100 90.3333 100 curveto
+stroke
+grestore
+% b->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 91.6993 98.8491 moveto
+86.5742 92.3442 80.9322 85.1832 76.336 79.3495 curveto
+stroke
+0 0 0 edgecolor
+newpath 78.8018 76.8237 moveto
+69.8638 71.1348 lineto
+73.3033 81.1558 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 78.8018 76.8237 moveto
+69.8638 71.1348 lineto
+73.3033 81.1558 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 82 moveto 2.779 ( ) alignedtext
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+64 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 51.3333 1 moveto
+51.3333 1 82.6667 1 82.6667 1 curveto
+88.3333 1 94 6.6667 94 12.3333 curveto
+94 12.3333 94 23.6667 94 23.6667 curveto
+94 29.3333 88.3333 35 82.6667 35 curveto
+82.6667 35 51.3333 35 51.3333 35 curveto
+45.6667 35 40 29.3333 40 23.6667 curveto
+40 23.6667 40 12.3333 40 12.3333 curveto
+40 6.6667 45.6667 1 51.3333 1 curveto
+stroke
+grestore
+% ]->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 67 63.9401 moveto
+67 60.0676 67 53.4899 67 46.5035 curveto
+stroke
+0 0 0 edgecolor
+newpath 70.5001 46.243 moveto
+67 36.243 lineto
+63.5001 46.2431 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 70.5001 46.243 moveto
+67 36.243 lineto
+63.5001 46.2431 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+67 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/400pseudo-state-join.eps
+++ b/test/render/fixtures/400pseudo-state-join.eps
@@ -1,0 +1,341 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 179
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 179
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 143 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 113.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 100 moveto
+12.3333 100 43.6667 100 43.6667 100 curveto
+49.3333 100 55 105.6667 55 111.3333 curveto
+55 111.3333 55 122.6667 55 122.6667 curveto
+55 128.3333 49.3333 134 43.6667 134 curveto
+43.6667 134 12.3333 134 12.3333 134 curveto
+6.6667 134 1 128.3333 1 122.6667 curveto
+1 122.6667 1 111.3333 1 111.3333 curveto
+1 105.6667 6.6667 100 12.3333 100 curveto
+stroke
+grestore
+% ]
+gsave
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+65.3326 63.9 moveto 3.3348 ( ) alignedtext
+grestore
+% a->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 42.3007 98.8491 moveto
+47.4258 92.3442 53.0678 85.1832 57.664 79.3495 curveto
+stroke
+0 0 0 edgecolor
+newpath 60.6967 81.1558 moveto
+64.1362 71.1348 lineto
+55.1982 76.8237 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 60.6967 81.1558 moveto
+64.1362 71.1348 lineto
+55.1982 76.8237 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 82 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+102.6646 113.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 100 moveto
+90.3333 100 121.6667 100 121.6667 100 curveto
+127.3333 100 133 105.6667 133 111.3333 curveto
+133 111.3333 133 122.6667 133 122.6667 curveto
+133 128.3333 127.3333 134 121.6667 134 curveto
+121.6667 134 90.3333 134 90.3333 134 curveto
+84.6667 134 79 128.3333 79 122.6667 curveto
+79 122.6667 79 111.3333 79 111.3333 curveto
+79 105.6667 84.6667 100 90.3333 100 curveto
+stroke
+grestore
+% b->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 91.6993 98.8491 moveto
+86.5742 92.3442 80.9322 85.1832 76.336 79.3495 curveto
+stroke
+0 0 0 edgecolor
+newpath 78.8018 76.8237 moveto
+69.8638 71.1348 lineto
+73.3033 81.1558 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 78.8018 76.8237 moveto
+69.8638 71.1348 lineto
+73.3033 81.1558 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 82 moveto 2.779 ( ) alignedtext
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+64 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 51.3333 1 moveto
+51.3333 1 82.6667 1 82.6667 1 curveto
+88.3333 1 94 6.6667 94 12.3333 curveto
+94 12.3333 94 23.6667 94 23.6667 curveto
+94 29.3333 88.3333 35 82.6667 35 curveto
+82.6667 35 51.3333 35 51.3333 35 curveto
+45.6667 35 40 29.3333 40 23.6667 curveto
+40 23.6667 40 12.3333 40 12.3333 curveto
+40 6.6667 45.6667 1 51.3333 1 curveto
+stroke
+grestore
+% ]->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 67 63.9401 moveto
+67 60.0676 67 53.4899 67 46.5035 curveto
+stroke
+0 0 0 edgecolor
+newpath 70.5001 46.243 moveto
+67 36.243 lineto
+63.5001 46.2431 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 70.5001 46.243 moveto
+67 36.243 lineto
+63.5001 46.2431 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+67 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/401pseudo-state-fork-explicit.eps
+++ b/test/render/fixtures/401pseudo-state-fork-explicit.eps
@@ -1,0 +1,341 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 179
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 179
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 143 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+63.6646 113.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 51.3333 100 moveto
+51.3333 100 82.6667 100 82.6667 100 curveto
+88.3333 100 94 105.6667 94 111.3333 curveto
+94 111.3333 94 122.6667 94 122.6667 curveto
+94 128.3333 88.3333 134 82.6667 134 curveto
+82.6667 134 51.3333 134 51.3333 134 curveto
+45.6667 134 40 128.3333 40 122.6667 curveto
+40 122.6667 40 111.3333 40 111.3333 curveto
+40 105.6667 45.6667 100 51.3333 100 curveto
+stroke
+grestore
+% ]
+gsave
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+65.3326 63.9 moveto 3.3348 ( ) alignedtext
+grestore
+% a->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 67 98.8491 moveto
+67 93.1375 67 86.9201 67 81.5394 curveto
+stroke
+0 0 0 edgecolor
+newpath 70.5001 81.1348 moveto
+67 71.1348 lineto
+63.5001 81.1349 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 70.5001 81.1348 moveto
+67 71.1348 lineto
+63.5001 81.1349 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+67 82 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+103 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 1 moveto
+90.3333 1 121.6667 1 121.6667 1 curveto
+127.3333 1 133 6.6667 133 12.3333 curveto
+133 12.3333 133 23.6667 133 23.6667 curveto
+133 29.3333 127.3333 35 121.6667 35 curveto
+121.6667 35 90.3333 35 90.3333 35 curveto
+84.6667 35 79 29.3333 79 23.6667 curveto
+79 23.6667 79 12.3333 79 12.3333 curveto
+79 6.6667 84.6667 1 90.3333 1 curveto
+stroke
+grestore
+% ]->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 64.1952 63.9401 moveto
+60.8604 59.7074 54.9791 52.2427 48.9143 44.5451 curveto
+stroke
+0 0 0 edgecolor
+newpath 51.3113 41.9319 moveto
+42.3733 36.243 lineto
+45.8128 46.264 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 51.3113 41.9319 moveto
+42.3733 36.243 lineto
+45.8128 46.264 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 47 moveto 2.779 ( ) alignedtext
+grestore
+% ]->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 69.8048 63.9401 moveto
+73.1396 59.7074 79.0209 52.2427 85.0857 44.5451 curveto
+stroke
+0 0 0 edgecolor
+newpath 88.1872 46.264 moveto
+91.6267 36.243 lineto
+82.6887 41.9319 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 88.1872 46.264 moveto
+91.6267 36.243 lineto
+82.6887 41.9319 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/401pseudo-state-fork.eps
+++ b/test/render/fixtures/401pseudo-state-fork.eps
@@ -1,0 +1,341 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 179
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 179
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 143 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+63.6646 113.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 51.3333 100 moveto
+51.3333 100 82.6667 100 82.6667 100 curveto
+88.3333 100 94 105.6667 94 111.3333 curveto
+94 111.3333 94 122.6667 94 122.6667 curveto
+94 128.3333 88.3333 134 82.6667 134 curveto
+82.6667 134 51.3333 134 51.3333 134 curveto
+45.6667 134 40 128.3333 40 122.6667 curveto
+40 122.6667 40 111.3333 40 111.3333 curveto
+40 105.6667 45.6667 100 51.3333 100 curveto
+stroke
+grestore
+% ]
+gsave
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 94 71 moveto
+40 71 lineto
+40 64 lineto
+94 64 lineto
+closepath stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+65.3326 63.9 moveto 3.3348 ( ) alignedtext
+grestore
+% a->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 67 98.8491 moveto
+67 93.1375 67 86.9201 67 81.5394 curveto
+stroke
+0 0 0 edgecolor
+newpath 70.5001 81.1348 moveto
+67 71.1348 lineto
+63.5001 81.1349 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 70.5001 81.1348 moveto
+67 71.1348 lineto
+63.5001 81.1349 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+67 82 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+103 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 1 moveto
+90.3333 1 121.6667 1 121.6667 1 curveto
+127.3333 1 133 6.6667 133 12.3333 curveto
+133 12.3333 133 23.6667 133 23.6667 curveto
+133 29.3333 127.3333 35 121.6667 35 curveto
+121.6667 35 90.3333 35 90.3333 35 curveto
+84.6667 35 79 29.3333 79 23.6667 curveto
+79 23.6667 79 12.3333 79 12.3333 curveto
+79 6.6667 84.6667 1 90.3333 1 curveto
+stroke
+grestore
+% ]->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 64.1952 63.9401 moveto
+60.8604 59.7074 54.9791 52.2427 48.9143 44.5451 curveto
+stroke
+0 0 0 edgecolor
+newpath 51.3113 41.9319 moveto
+42.3733 36.243 lineto
+45.8128 46.264 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 51.3113 41.9319 moveto
+42.3733 36.243 lineto
+45.8128 46.264 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 47 moveto 2.779 ( ) alignedtext
+grestore
+% ]->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 69.8048 63.9401 moveto
+73.1396 59.7074 79.0209 52.2427 85.0857 44.5451 curveto
+stroke
+0 0 0 edgecolor
+newpath 88.1872 46.264 moveto
+91.6267 36.243 lineto
+82.6887 41.9319 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 88.1872 46.264 moveto
+91.6267 36.243 lineto
+82.6887 41.9319 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/402pseudo-state-junction-explicit.eps
+++ b/test/render/fixtures/402pseudo-state-junction-explicit.eps
@@ -1,0 +1,372 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 183
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 183
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 147 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 117.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 104 moveto
+12.3333 104 43.6667 104 43.6667 104 curveto
+49.3333 104 55 109.6667 55 115.3333 curveto
+55 115.3333 55 126.6667 55 126.6667 curveto
+55 132.3333 49.3333 138 43.6667 138 curveto
+43.6667 138 12.3333 138 12.3333 138 curveto
+6.6667 138 1 132.3333 1 126.6667 curveto
+1 126.6667 1 115.3333 1 115.3333 curveto
+1 109.6667 6.6667 104 12.3333 104 curveto
+stroke
+grestore
+% ]
+gsave
+0 0 0 nodecolor
+67 69.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+67 69.5 5.5 5.5 ellipse_path stroke
+grestore
+% a->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 41.6403 102.9878 moveto
+46.7144 96.2874 52.372 88.8164 57.0538 82.6341 curveto
+stroke
+0 0 0 edgecolor
+newpath 60.1366 84.3608 moveto
+63.3835 74.2757 lineto
+54.5561 80.1348 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 60.1366 84.3608 moveto
+63.3835 74.2757 lineto
+54.5561 80.1348 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+57 86 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+102.6646 117.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 104 moveto
+90.3333 104 121.6667 104 121.6667 104 curveto
+127.3333 104 133 109.6667 133 115.3333 curveto
+133 115.3333 133 126.6667 133 126.6667 curveto
+133 132.3333 127.3333 138 121.6667 138 curveto
+121.6667 138 90.3333 138 90.3333 138 curveto
+84.6667 138 79 132.3333 79 126.6667 curveto
+79 126.6667 79 115.3333 79 115.3333 curveto
+79 109.6667 84.6667 104 90.3333 104 curveto
+stroke
+grestore
+% b->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 92.3597 102.9878 moveto
+87.2856 96.2874 81.628 88.8164 76.9462 82.6341 curveto
+stroke
+0 0 0 edgecolor
+newpath 79.4439 80.1348 moveto
+70.6165 74.2757 lineto
+73.8634 84.3608 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 79.4439 80.1348 moveto
+70.6165 74.2757 lineto
+73.8634 84.3608 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 86 moveto 2.779 ( ) alignedtext
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+25 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+102.6646 14.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 1 moveto
+90.3333 1 121.6667 1 121.6667 1 curveto
+127.3333 1 133 6.6667 133 12.3333 curveto
+133 12.3333 133 23.6667 133 23.6667 curveto
+133 29.3333 127.3333 35 121.6667 35 curveto
+121.6667 35 90.3333 35 90.3333 35 curveto
+84.6667 35 79 29.3333 79 23.6667 curveto
+79 23.6667 79 12.3333 79 12.3333 curveto
+79 6.6667 84.6667 1 90.3333 1 curveto
+stroke
+grestore
+% ]->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 63.6749 65.1091 moveto
+60.1203 60.4153 54.1776 52.5678 48.1518 44.6107 curveto
+stroke
+0 0 0 edgecolor
+newpath 50.7661 42.2654 moveto
+41.9388 36.4063 lineto
+45.1857 46.4914 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 50.7661 42.2654 moveto
+41.9388 36.4063 lineto
+45.1857 46.4914 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+57 47 moveto 2.779 ( ) alignedtext
+grestore
+% ]->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 70.3251 65.1091 moveto
+73.8797 60.4153 79.8224 52.5678 85.8482 44.6107 curveto
+stroke
+0 0 0 edgecolor
+newpath 88.8143 46.4914 moveto
+92.0612 36.4063 lineto
+83.2339 42.2654 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 88.8143 46.4914 moveto
+92.0612 36.4063 lineto
+83.2339 42.2654 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/402pseudo-state-junction.eps
+++ b/test/render/fixtures/402pseudo-state-junction.eps
@@ -1,0 +1,372 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 183
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 183
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 147 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 117.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 104 moveto
+12.3333 104 43.6667 104 43.6667 104 curveto
+49.3333 104 55 109.6667 55 115.3333 curveto
+55 115.3333 55 126.6667 55 126.6667 curveto
+55 132.3333 49.3333 138 43.6667 138 curveto
+43.6667 138 12.3333 138 12.3333 138 curveto
+6.6667 138 1 132.3333 1 126.6667 curveto
+1 126.6667 1 115.3333 1 115.3333 curveto
+1 109.6667 6.6667 104 12.3333 104 curveto
+stroke
+grestore
+% ]
+gsave
+0 0 0 nodecolor
+67 69.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+67 69.5 5.5 5.5 ellipse_path stroke
+grestore
+% a->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 41.6403 102.9878 moveto
+46.7144 96.2874 52.372 88.8164 57.0538 82.6341 curveto
+stroke
+0 0 0 edgecolor
+newpath 60.1366 84.3608 moveto
+63.3835 74.2757 lineto
+54.5561 80.1348 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 60.1366 84.3608 moveto
+63.3835 74.2757 lineto
+54.5561 80.1348 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+57 86 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+102.6646 117.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 104 moveto
+90.3333 104 121.6667 104 121.6667 104 curveto
+127.3333 104 133 109.6667 133 115.3333 curveto
+133 115.3333 133 126.6667 133 126.6667 curveto
+133 132.3333 127.3333 138 121.6667 138 curveto
+121.6667 138 90.3333 138 90.3333 138 curveto
+84.6667 138 79 132.3333 79 126.6667 curveto
+79 126.6667 79 115.3333 79 115.3333 curveto
+79 109.6667 84.6667 104 90.3333 104 curveto
+stroke
+grestore
+% b->]
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 92.3597 102.9878 moveto
+87.2856 96.2874 81.628 88.8164 76.9462 82.6341 curveto
+stroke
+0 0 0 edgecolor
+newpath 79.4439 80.1348 moveto
+70.6165 74.2757 lineto
+73.8634 84.3608 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 79.4439 80.1348 moveto
+70.6165 74.2757 lineto
+73.8634 84.3608 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 86 moveto 2.779 ( ) alignedtext
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+25 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+102.6646 14.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 90.3333 1 moveto
+90.3333 1 121.6667 1 121.6667 1 curveto
+127.3333 1 133 6.6667 133 12.3333 curveto
+133 12.3333 133 23.6667 133 23.6667 curveto
+133 29.3333 127.3333 35 121.6667 35 curveto
+121.6667 35 90.3333 35 90.3333 35 curveto
+84.6667 35 79 29.3333 79 23.6667 curveto
+79 23.6667 79 12.3333 79 12.3333 curveto
+79 6.6667 84.6667 1 90.3333 1 curveto
+stroke
+grestore
+% ]->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 63.6749 65.1091 moveto
+60.1203 60.4153 54.1776 52.5678 48.1518 44.6107 curveto
+stroke
+0 0 0 edgecolor
+newpath 50.7661 42.2654 moveto
+41.9388 36.4063 lineto
+45.1857 46.4914 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 50.7661 42.2654 moveto
+41.9388 36.4063 lineto
+45.1857 46.4914 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+57 47 moveto 2.779 ( ) alignedtext
+grestore
+% ]->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 70.3251 65.1091 moveto
+73.8797 60.4153 79.8224 52.5678 85.8482 44.6107 curveto
+stroke
+0 0 0 edgecolor
+newpath 88.8143 46.4914 moveto
+92.0612 36.4063 lineto
+83.2339 42.2654 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 88.8143 46.4914 moveto
+92.0612 36.4063 lineto
+83.2339 42.2654 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+85 47 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/403pseudo-state-choice.eps
+++ b/test/render/fixtures/403pseudo-state-choice.eps
@@ -1,0 +1,384 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 318 197
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 318 197
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 282 161 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+104.6646 131.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 92.3333 118 moveto
+92.3333 118 123.6667 118 123.6667 118 curveto
+129.3333 118 135 123.6667 135 129.3333 curveto
+135 129.3333 135 140.6667 135 140.6667 curveto
+135 146.3333 129.3333 152 123.6667 152 curveto
+123.6667 152 92.3333 152 92.3333 152 curveto
+86.6667 152 81 146.3333 81 140.6667 curveto
+81 140.6667 81 129.3333 81 129.3333 curveto
+81 123.6667 86.6667 118 92.3333 118 curveto
+stroke
+grestore
+% ^
+gsave
+2 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 108 89 moveto
+95.5 76.5 lineto
+108 64 lineto
+120.5 76.5 lineto
+closepath stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+106.6105 73.5 moveto 2.779 ( ) alignedtext
+grestore
+% a->^
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 108 116.8109 moveto
+108 111.3333 108 105.2488 108 99.5018 curveto
+stroke
+0 0 0 edgecolor
+newpath 111.5001 99.1148 moveto
+108 89.1149 lineto
+104.5001 99.1149 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 111.5001 99.1148 moveto
+108 89.1149 lineto
+104.5001 99.1149 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+108 100 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+105 14.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 92.3333 1 moveto
+92.3333 1 123.6667 1 123.6667 1 curveto
+129.3333 1 135 6.6667 135 12.3333 curveto
+135 12.3333 135 23.6667 135 23.6667 curveto
+135 29.3333 129.3333 35 123.6667 35 curveto
+123.6667 35 92.3333 35 92.3333 35 curveto
+86.6667 35 81 29.3333 81 23.6667 curveto
+81 23.6667 81 12.3333 81 12.3333 curveto
+81 6.6667 86.6667 1 92.3333 1 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+182.6646 14.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 170.3333 1 moveto
+170.3333 1 201.6667 1 201.6667 1 curveto
+207.3333 1 213 6.6667 213 12.3333 curveto
+213 12.3333 213 23.6667 213 23.6667 curveto
+213 29.3333 207.3333 35 201.6667 35 curveto
+201.6667 35 170.3333 35 170.3333 35 curveto
+164.6667 35 159 29.3333 159 23.6667 curveto
+159 23.6667 159 12.3333 159 12.3333 curveto
+159 6.6667 164.6667 1 170.3333 1 curveto
+stroke
+grestore
+% ^->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 96.6442 74.8573 moveto
+84.0855 72.5403 63.8315 67.265 50.219 56 curveto
+46.4436 52.8756 43.1654 48.9322 40.3723 44.7761 curveto
+stroke
+0 0 0 edgecolor
+newpath 43.3894 43.002 moveto
+35.3164 36.1407 lineto
+37.3486 46.5388 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 43.3894 43.002 moveto
+35.3164 36.1407 lineto
+37.3486 46.5388 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+51 47 moveto 52.781 (misschien   ) alignedtext
+grestore
+% ^->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 108 63.8064 moveto
+108 58.6397 108 52.4455 108 46.3067 curveto
+stroke
+0 0 0 edgecolor
+newpath 111.5001 46.2191 moveto
+108 36.2191 lineto
+104.5001 46.2191 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 111.5001 46.2191 moveto
+108 36.2191 lineto
+104.5001 46.2191 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+108 47 moveto 16.115 (ja   ) alignedtext
+grestore
+% ^->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 115.1982 71.1013 moveto
+123.9626 64.528 139.3571 52.9822 153.5574 42.3319 curveto
+stroke
+0 0 0 edgecolor
+newpath 155.8212 45.0091 moveto
+161.7212 36.2091 lineto
+151.6212 39.4091 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 155.8212 45.0091 moveto
+161.7212 36.2091 lineto
+151.6212 39.4091 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+149 47 moveto 25.014 (nee   ) alignedtext
+grestore
+% ^->^
+gsave
+0 0 0 edgecolor
+10 /Helvetica set_font
+142.5 73.5 moveto 131.714 (kent u de weg naar hamelen?) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/403pseudo-state-terminate.eps
+++ b/test/render/fixtures/403pseudo-state-terminate.eps
@@ -1,0 +1,246 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 100 160
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 100 160
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 64 124 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 94.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 81 moveto
+12.3333 81 43.6667 81 43.6667 81 curveto
+49.3333 81 55 86.6667 55 92.3333 curveto
+55 92.3333 55 103.6667 55 103.6667 curveto
+55 109.3333 49.3333 115 43.6667 115 curveto
+43.6667 115 12.3333 115 12.3333 115 curveto
+6.6667 115 1 109.3333 1 103.6667 curveto
+1 103.6667 1 92.3333 1 92.3333 curveto
+1 86.6667 6.6667 81 12.3333 81 curveto
+stroke
+grestore
+% t
+gsave
+0 0 0 nodecolor
+20 /Helvetica set_font
+21.831 28 moveto 13.338 (X) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+26.8326 9.2 moveto 3.3348 (t) alignedtext
+grestore
+% a->t
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 79.8314 moveto
+28 74.4404 28 68.3358 28 62.2226 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 62.0509 moveto
+28 52.0509 lineto
+24.5001 62.0509 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 62.0509 moveto
+28 52.0509 lineto
+24.5001 62.0509 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 63 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/500hierarchic-states.eps
+++ b/test/render/fixtures/500hierarchic-states.eps
@@ -1,0 +1,252 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 232 142
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 232 142
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 196 106 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_a
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 168 8 168 8 curveto
+174 8 180 14 180 20 curveto
+180 20 180 78 180 78 curveto
+180 84 174 90 168 90 curveto
+168 90 20 90 20 90 curveto
+14 90 8 84 8 78 curveto
+8 78 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+90.6646 71.2 moveto 6.6708 (a) alignedtext
+grestore
+% a
+% aa
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+115.3292 30.2 moveto 13.3416 (aa) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 106.3333 17 moveto
+106.3333 17 137.6667 17 137.6667 17 curveto
+143.3333 17 149 22.6667 149 28.3333 curveto
+149 28.3333 149 39.6667 149 39.6667 curveto
+149 45.3333 143.3333 51 137.6667 51 curveto
+137.6667 51 106.3333 51 106.3333 51 curveto
+100.6667 51 95 45.3333 95 39.6667 curveto
+95 39.6667 95 28.3333 95 28.3333 curveto
+95 22.6667 100.6667 17 106.3333 17 curveto
+stroke
+grestore
+% ab
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+37.3292 30.2 moveto 13.3416 (ab) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/501hierarchic-states-with-transitions.eps
+++ b/test/render/fixtures/501hierarchic-states-with-transitions.eps
@@ -1,0 +1,275 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 154 224
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 154 224
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 118 188 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_a
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 90 8 90 8 curveto
+96 8 102 14 102 20 curveto
+102 20 102 160 102 160 curveto
+102 166 96 172 90 172 curveto
+90 172 20 172 20 172 curveto
+14 172 8 166 8 160 curveto
+8 160 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+51.6646 153.2 moveto 6.6708 (a) alignedtext
+grestore
+% a
+% aa
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+37.3292 112.2 moveto 13.3416 (aa) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 99 moveto
+28.3333 99 59.6667 99 59.6667 99 curveto
+65.3333 99 71 104.6667 71 110.3333 curveto
+71 110.3333 71 121.6667 71 121.6667 curveto
+71 127.3333 65.3333 133 59.6667 133 curveto
+59.6667 133 28.3333 133 28.3333 133 curveto
+22.6667 133 17 127.3333 17 121.6667 curveto
+17 121.6667 17 110.3333 17 110.3333 curveto
+17 104.6667 22.6667 99 28.3333 99 curveto
+stroke
+grestore
+% ab
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+37.3292 30.2 moveto 13.3416 (ab) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% aa->ab
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 44 97.8015 moveto
+44 87.3976 44 74.1215 44 62.3768 curveto
+stroke
+0 0 0 edgecolor
+newpath 47.5001 62.1476 moveto
+44 52.1476 lineto
+40.5001 62.1476 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 47.5001 62.1476 moveto
+44 52.1476 lineto
+40.5001 62.1476 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+44 72 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/502hierarchic-one-state-with-onentries.eps
+++ b/test/render/fixtures/502hierarchic-one-state-with-onentries.eps
@@ -1,0 +1,298 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 202 284
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 202 284
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 166 248 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_a
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 138 8 138 8 curveto
+144 8 150 14 150 20 curveto
+150 20 150 220 150 220 curveto
+150 226 144 232 138 232 curveto
+138 232 20 232 20 232 curveto
+14 232 8 226 8 220 curveto
+8 220 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+75.6646 213.2 moveto 6.6708 (a) alignedtext
+0 0 0 graphcolor
+12 /Helvetica set_font
+20 193.2 moveto 58.6788 (entry/ hello) alignedtext
+0 0 0 graphcolor
+12 /Helvetica set_font
+19.9774 173.2 moveto 118.0452 (entry/ how do you do?) alignedtext
+0 0 0 graphcolor
+12 /Helvetica set_font
+20 153.2 moveto 67.356 (exit/ bye bye) alignedtext
+0 0 0 graphcolor
+newpath 16 207 moveto
+16 207 lineto
+142 207 lineto
+142 207 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 graphcolor
+newpath 16 207 moveto
+16 207 lineto
+142 207 lineto
+142 207 lineto
+closepath stroke
+grestore
+% a
+% aa
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+49.3292 112.2 moveto 13.3416 (aa) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 40.3333 99 moveto
+40.3333 99 71.6667 99 71.6667 99 curveto
+77.3333 99 83 104.6667 83 110.3333 curveto
+83 110.3333 83 121.6667 83 121.6667 curveto
+83 127.3333 77.3333 133 71.6667 133 curveto
+71.6667 133 40.3333 133 40.3333 133 curveto
+34.6667 133 29 127.3333 29 121.6667 curveto
+29 121.6667 29 110.3333 29 110.3333 curveto
+29 104.6667 34.6667 99 40.3333 99 curveto
+stroke
+grestore
+% ab
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+49.3292 30.2 moveto 13.3416 (ab) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 40.3333 17 moveto
+40.3333 17 71.6667 17 71.6667 17 curveto
+77.3333 17 83 22.6667 83 28.3333 curveto
+83 28.3333 83 39.6667 83 39.6667 curveto
+83 45.3333 77.3333 51 71.6667 51 curveto
+71.6667 51 40.3333 51 40.3333 51 curveto
+34.6667 51 29 45.3333 29 39.6667 curveto
+29 39.6667 29 28.3333 29 28.3333 curveto
+29 22.6667 34.6667 17 40.3333 17 curveto
+stroke
+grestore
+% aa->ab
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 56 97.8015 moveto
+56 87.3976 56 74.1215 56 62.3768 curveto
+stroke
+0 0 0 edgecolor
+newpath 59.5001 62.1476 moveto
+56 52.1476 lineto
+52.5001 62.1476 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 59.5001 62.1476 moveto
+56 52.1476 lineto
+52.5001 62.1476 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+56 72 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/506hierarchical-with-text-that-needs-escaping.eps
+++ b/test/render/fixtures/506hierarchical-with-text-that-needs-escaping.eps
@@ -1,0 +1,250 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 185 162
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 185 162
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 149 126 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_nest
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 121 8 121 8 curveto
+127 8 133 14 133 20 curveto
+133 20 133 98 133 98 curveto
+133 104 127 110 121 110 curveto
+121 110 20 110 20 110 curveto
+14 110 8 104 8 98 curveto
+8 98 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+36.32 91.2 moveto 69.36 (<something>) alignedtext
+0 0 0 graphcolor
+12 /Helvetica set_font
+20.1482 71.2 moveto 101.7036 (entry/ [x>y] do stuff) alignedtext
+0 0 0 graphcolor
+newpath 16.5 85 moveto
+16.5 85 lineto
+125.5 85 lineto
+125.5 85 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 graphcolor
+newpath 16.5 85 moveto
+16.5 85 lineto
+125.5 85 lineto
+125.5 85 lineto
+closepath stroke
+grestore
+% nest
+% egg
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+48.9938 30.2 moveto 20.0124 (egg) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 43.3333 17 moveto
+43.3333 17 74.6667 17 74.6667 17 curveto
+80.3333 17 86 22.6667 86 28.3333 curveto
+86 28.3333 86 39.6667 86 39.6667 curveto
+86 45.3333 80.3333 51 74.6667 51 curveto
+74.6667 51 43.3333 51 43.3333 51 curveto
+37.6667 51 32 45.3333 32 39.6667 curveto
+32 39.6667 32 28.3333 32 28.3333 curveto
+32 22.6667 37.6667 17 43.3333 17 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/510hierarchical-one-initial-state.eps
+++ b/test/render/fixtures/510hierarchical-one-initial-state.eps
@@ -1,0 +1,223 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 117
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 117
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 81 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_something nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 114 8 114 8 curveto
+120 8 126 14 126 20 curveto
+126 20 126 53 126 53 curveto
+126 59 120 65 114 65 curveto
+114 65 20 65 20 65 curveto
+14 65 8 59 8 53 curveto
+8 53 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+19.6504 46.2 moveto 94.6992 (something nested) alignedtext
+grestore
+% something nested
+% initial
+gsave
+0 0 0 nodecolor
+56 21.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+56 21.5 5.5 5.5 ellipse_path stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/511hierarchical-with-initial-state-pointing-somehwhere.eps
+++ b/test/render/fixtures/511hierarchical-with-initial-state-pointing-somehwhere.eps
@@ -1,0 +1,265 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 199
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 199
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 163 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_something nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 114 8 114 8 curveto
+120 8 126 14 126 20 curveto
+126 20 126 135 126 135 curveto
+126 141 120 147 114 147 curveto
+114 147 20 147 20 147 curveto
+14 147 8 141 8 135 curveto
+8 135 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+19.6504 128.2 moveto 94.6992 (something nested) alignedtext
+grestore
+% something nested
+% initial
+gsave
+0 0 0 nodecolor
+64 103.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+64 103.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+34.6588 30.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 36.3333 17 moveto
+36.3333 17 91.6667 17 91.6667 17 curveto
+97.3333 17 103 22.6667 103 28.3333 curveto
+103 28.3333 103 39.6667 103 39.6667 curveto
+103 45.3333 97.3333 51 91.6667 51 curveto
+91.6667 51 36.3333 51 36.3333 51 curveto
+30.6667 51 25 45.3333 25 39.6667 curveto
+25 39.6667 25 28.3333 25 28.3333 curveto
+25 22.6667 30.6667 17 36.3333 17 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 64 97.5745 moveto
+64 89.7003 64 75.2498 64 62.1135 curveto
+stroke
+0 0 0 edgecolor
+newpath 67.5001 62.0109 moveto
+64 52.011 lineto
+60.5001 62.011 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 67.5001 62.0109 moveto
+64 52.011 lineto
+60.5001 62.011 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+64 72 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/512hierarchical-with-initial-state-pointing-somehwhere-with-an-event.eps
+++ b/test/render/fixtures/512hierarchical-with-initial-state-pointing-somehwhere-with-an-event.eps
@@ -1,0 +1,265 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 190 199
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 190 199
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 154 163 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_something nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 126 8 126 8 curveto
+132 8 138 14 138 20 curveto
+138 20 138 135 138 135 curveto
+138 141 132 147 126 147 curveto
+126 147 20 147 20 147 curveto
+14 147 8 141 8 135 curveto
+8 135 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+25.6504 128.2 moveto 94.6992 (something nested) alignedtext
+grestore
+% something nested
+% initial
+gsave
+0 0 0 nodecolor
+38 103.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+38 103.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+26.6588 30.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 83.6667 17 83.6667 17 curveto
+89.3333 17 95 22.6667 95 28.3333 curveto
+95 28.3333 95 39.6667 95 39.6667 curveto
+95 45.3333 89.3333 51 83.6667 51 curveto
+83.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 39.4124 98.0465 moveto
+41.4333 90.2435 45.2917 75.3459 48.779 61.8812 curveto
+stroke
+0 0 0 edgecolor
+newpath 52.2177 62.5635 moveto
+51.3368 52.0053 lineto
+45.4413 60.8084 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 52.2177 62.5635 moveto
+51.3368 52.0053 lineto
+45.4413 60.8084 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+46 72 moveto 92.253 (an awesome event   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/513hierarchical-with-initial-state-pointing-somehwhere-with-a-condition.eps
+++ b/test/render/fixtures/513hierarchical-with-initial-state-pointing-somehwhere-with-a-condition.eps
@@ -1,0 +1,265 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 178 199
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 178 199
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 142 163 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_something nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 114 8 114 8 curveto
+120 8 126 14 126 20 curveto
+126 20 126 135 126 135 curveto
+126 141 120 147 114 147 curveto
+114 147 20 147 20 147 curveto
+14 147 8 141 8 135 curveto
+8 135 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+19.6504 128.2 moveto 94.6992 (something nested) alignedtext
+grestore
+% something nested
+% initial
+gsave
+0 0 0 nodecolor
+64 103.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+64 103.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+34.6588 30.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 36.3333 17 moveto
+36.3333 17 91.6667 17 91.6667 17 curveto
+97.3333 17 103 22.6667 103 28.3333 curveto
+103 28.3333 103 39.6667 103 39.6667 curveto
+103 45.3333 97.3333 51 91.6667 51 curveto
+91.6667 51 36.3333 51 36.3333 51 curveto
+30.6667 51 25 45.3333 25 39.6667 curveto
+25 39.6667 25 28.3333 25 28.3333 curveto
+25 22.6667 30.6667 17 36.3333 17 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 64 97.5745 moveto
+64 89.7003 64 75.2498 64 62.1135 curveto
+stroke
+0 0 0 edgecolor
+newpath 67.5001 62.0109 moveto
+64 52.011 lineto
+60.5001 62.011 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 67.5001 62.0109 moveto
+64 52.011 lineto
+60.5001 62.011 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+64 72 moveto 29.454 ([yes]   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/514hierarchical-with-initial-state-pointing-somehwhere-with-an-action.eps
+++ b/test/render/fixtures/514hierarchical-with-initial-state-pointing-somehwhere-with-an-action.eps
@@ -1,0 +1,265 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 253 199
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 253 199
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 217 163 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_something nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 189 8 189 8 curveto
+195 8 201 14 201 20 curveto
+201 20 201 135 201 135 curveto
+201 141 195 147 189 147 curveto
+189 147 20 147 20 147 curveto
+14 147 8 141 8 135 curveto
+8 135 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+57.1504 128.2 moveto 94.6992 (something nested) alignedtext
+grestore
+% something nested
+% initial
+gsave
+0 0 0 nodecolor
+38 103.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+38 103.5 5.5 5.5 ellipse_path stroke
+grestore
+% some state
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+26.6588 30.2 moveto 58.6824 (some state) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 83.6667 17 83.6667 17 curveto
+89.3333 17 95 22.6667 95 28.3333 curveto
+95 28.3333 95 39.6667 95 39.6667 curveto
+95 45.3333 89.3333 51 83.6667 51 curveto
+83.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% initial->some state
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 39.4124 98.0465 moveto
+41.4333 90.2435 45.2917 75.3459 48.779 61.8812 curveto
+stroke
+0 0 0 edgecolor
+newpath 52.2177 62.5635 moveto
+51.3368 52.0053 lineto
+45.4413 60.8084 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 52.2177 62.5635 moveto
+51.3368 52.0053 lineto
+45.4413 60.8084 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+46 72 moveto 155.04 (/ here's some executable content   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/515hierarchical-with-transitions-defined-outside.eps
+++ b/test/render/fixtures/515hierarchical-with-transitions-defined-outside.eps
@@ -1,0 +1,269 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 154 181
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 154 181
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 118 145 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_a
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 47 moveto
+20 47 90 47 90 47 curveto
+96 47 102 53 102 59 curveto
+102 59 102 117 102 117 curveto
+102 123 96 129 90 129 curveto
+90 129 20 129 20 129 curveto
+14 129 8 123 8 117 curveto
+8 117 8 59 8 59 curveto
+8 53 14 47 20 47 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+51.6646 110.2 moveto 6.6708 (a) alignedtext
+grestore
+% final
+gsave
+0 0 0 nodecolor
+44 9.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+44 9.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+44 9.5 9.5 9.5 ellipse_path stroke
+grestore
+% a
+% aa
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+37.3292 69.2 moveto 13.3416 (aa) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 56 moveto
+28.3333 56 59.6667 56 59.6667 56 curveto
+65.3333 56 71 61.6667 71 67.3333 curveto
+71 67.3333 71 78.6667 71 78.6667 curveto
+71 84.3333 65.3333 90 59.6667 90 curveto
+59.6667 90 28.3333 90 28.3333 90 curveto
+22.6667 90 17 84.3333 17 78.6667 curveto
+17 78.6667 17 67.3333 17 67.3333 curveto
+17 61.6667 22.6667 56 28.3333 56 curveto
+stroke
+grestore
+% aa->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 44 54.9733 moveto
+44 47.0074 44 37.6145 44 29.4397 curveto
+stroke
+0 0 0 edgecolor
+newpath 47.5001 29.2957 moveto
+44 19.2957 lineto
+40.5001 29.2958 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 47.5001 29.2957 moveto
+44 19.2957 lineto
+40.5001 29.2958 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+44 30 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/516hierarchical-issue-15.eps
+++ b/test/render/fixtures/516hierarchical-issue-15.eps
@@ -1,0 +1,544 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 598 398
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 598 398
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 562 362 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_PLAYER
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 478 8 478 8 curveto
+484 8 490 14 490 20 curveto
+490 20 490 334 490 334 curveto
+490 340 484 346 478 346 curveto
+478 346 20 346 20 346 curveto
+14 346 8 340 8 334 curveto
+8 334 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+225.8276 327.2 moveto 47.3448 (PLAYER) alignedtext
+grestore
+% cluster_RESTART_STREAM
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 28 16 moveto
+28 16 149 16 149 16 curveto
+155 16 161 22 161 28 curveto
+161 28 161 296 161 296 curveto
+161 302 155 308 149 308 curveto
+149 308 28 308 28 308 curveto
+22 308 16 302 16 296 curveto
+16 296 16 28 16 28 curveto
+16 22 22 16 28 16 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+32.1684 289.2 moveto 112.6632 (RESTART_STREAM) alignedtext
+grestore
+% APP
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+513.9958 102.2 moveto 24.0084 (APP) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 510.3333 89 moveto
+510.3333 89 541.6667 89 541.6667 89 curveto
+547.3333 89 553 94.6667 553 100.3333 curveto
+553 100.3333 553 111.6667 553 111.6667 curveto
+553 117.3333 547.3333 123 541.6667 123 curveto
+541.6667 123 510.3333 123 510.3333 123 curveto
+504.6667 123 499 117.3333 499 111.6667 curveto
+499 111.6667 499 100.3333 499 100.3333 curveto
+499 94.6667 504.6667 89 510.3333 89 curveto
+stroke
+grestore
+% LIVE_STREAM
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+313.6606 38.2 moveto 82.6788 (LIVE_STREAM) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 315.3333 25 moveto
+315.3333 25 394.6667 25 394.6667 25 curveto
+400.3333 25 406 30.6667 406 36.3333 curveto
+406 36.3333 406 47.6667 406 47.6667 curveto
+406 53.3333 400.3333 59 394.6667 59 curveto
+394.6667 59 315.3333 59 315.3333 59 curveto
+309.6667 59 304 53.3333 304 47.6667 curveto
+304 47.6667 304 36.3333 304 36.3333 curveto
+304 30.6667 309.6667 25 315.3333 25 curveto
+stroke
+grestore
+% APP->LIVE_STREAM
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 497.8835 89.7963 moveto
+496.5813 89.1689 495.2827 88.5667 494 88 curveto
+469.375 77.1214 441.335 67.3709 416.9201 59.677 curveto
+stroke
+0 0 0 edgecolor
+newpath 417.6415 56.2363 moveto
+407.0535 56.6164 lineto
+415.5675 62.922 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 417.6415 56.2363 moveto
+407.0535 56.6164 lineto
+415.5675 62.922 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+471 71 moveto 70.017 (start playback   ) alignedtext
+grestore
+% PLAYER
+% PLAYER->APP
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 489.996 225.4678 moveto
+497.7899 199.6064 509.5968 160.4287 517.5441 134.0584 curveto
+stroke
+0 0 0 edgecolor
+newpath 520.9639 134.8402 moveto
+520.4983 124.2556 lineto
+514.2616 132.8203 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 520.9639 134.8402 moveto
+520.4983 124.2556 lineto
+514.2616 132.8203 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+501 188 moveto 45.571 (on close   ) alignedtext
+grestore
+% PLAYING
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+79.9942 38.2 moveto 52.0116 (PLAYING) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 81.3333 25 moveto
+81.3333 25 130.6667 25 130.6667 25 curveto
+136.3333 25 142 30.6667 142 36.3333 curveto
+142 36.3333 142 47.6667 142 47.6667 curveto
+142 53.3333 136.3333 59 130.6667 59 curveto
+130.6667 59 81.3333 59 81.3333 59 curveto
+75.6667 59 70 53.3333 70 47.6667 curveto
+70 47.6667 70 36.3333 70 36.3333 curveto
+70 30.6667 75.6667 25 81.3333 25 curveto
+stroke
+grestore
+% LIVE_STREAM->PLAYING
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 302.5785 42 moveto
+258.3946 42 195.7358 42 153.1199 42 curveto
+stroke
+0 0 0 edgecolor
+newpath 153.009 38.5001 moveto
+143.0089 42 lineto
+153.0089 45.5001 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 153.009 38.5001 moveto
+143.0089 42 lineto
+153.0089 45.5001 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+183.8285 48 moveto 78.343 (switch to restart   ) alignedtext
+grestore
+% CONFIRM_SWITCH_TO_LIVE
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+185.5032 155.2 moveto 165.9936 (CONFIRM_SWITCH_TO_LIVE) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 186.8333 142 moveto
+186.8333 142 349.1667 142 349.1667 142 curveto
+354.8333 142 360.5 147.6667 360.5 153.3333 curveto
+360.5 153.3333 360.5 164.6667 360.5 164.6667 curveto
+360.5 170.3333 354.8333 176 349.1667 176 curveto
+349.1667 176 186.8333 176 186.8333 176 curveto
+181.1667 176 175.5 170.3333 175.5 164.6667 curveto
+175.5 164.6667 175.5 153.3333 175.5 153.3333 curveto
+175.5 147.6667 181.1667 142 186.8333 142 curveto
+stroke
+grestore
+% CONFIRM_SWITCH_TO_LIVE->LIVE_STREAM
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 275.8708 140.843 moveto
+282.7925 125.9048 293.7293 104.5715 306.441 88 curveto
+311.9274 80.8477 318.5513 73.8035 325.1184 67.4594 curveto
+stroke
+0 0 0 edgecolor
+newpath 327.7985 69.7462 moveto
+332.73 60.369 lineto
+323.0272 64.6241 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 327.7985 69.7462 moveto
+332.73 60.369 lineto
+323.0272 64.6241 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+306 103 moveto 100.559 (confirm switch to live   ) alignedtext
+grestore
+% CONFIRM_SWITCH_TO_LIVE->PLAYING
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 213.5914 140.9394 moveto
+202.7797 136.2212 191.8378 130.5757 182.319 124 curveto
+160.1799 108.706 139.6786 85.9912 125.5117 68.3445 curveto
+stroke
+0 0 0 edgecolor
+newpath 128.0088 65.8567 moveto
+119.0864 60.1434 lineto
+122.4986 70.1738 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 128.0088 65.8567 moveto
+119.0864 60.1434 lineto
+122.4986 70.1738 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+183 103 moveto 96.681 (cancel switch to live   ) alignedtext
+grestore
+% RESTART_STREAM
+% RESTART_STREAM->LIVE_STREAM
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 160.9968 231.0505 moveto
+179.6645 220.2343 227.9698 221.545 246 217 curveto
+303.3829 202.5352 325.7516 212.6317 373 177 curveto
+406.936 151.4077 425.6413 126.6704 408 88 curveto
+404.3654 80.0328 398.5939 72.9134 392.1719 66.7936 curveto
+stroke
+0 0 0 edgecolor
+newpath 394.2724 63.9825 moveto
+384.4233 60.0779 lineto
+389.6877 69.2723 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 394.2724 63.9825 moveto
+384.4233 60.0779 lineto
+389.6877 69.2723 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+407 156 moveto 76.124 (stream finished   ) alignedtext
+grestore
+% RESTART_STREAM->CONFIRM_SWITCH_TO_LIVE
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 161 228.4947 moveto
+176.1619 208.8801 198.0577 193.2882 218.0976 181.8846 curveto
+stroke
+0 0 0 edgecolor
+newpath 219.8922 184.8924 moveto
+226.9862 177.0232 lineto
+216.5332 178.751 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 219.8922 184.8924 moveto
+226.9862 177.0232 lineto
+216.5332 178.751 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+184 208 moveto 56.676 (start to live   ) alignedtext
+grestore
+% PAUSED
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+53.8316 248.2 moveto 49.3368 (PAUSED) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 54.8333 235 moveto
+54.8333 235 101.1667 235 101.1667 235 curveto
+106.8333 235 112.5 240.6667 112.5 246.3333 curveto
+112.5 246.3333 112.5 257.6667 112.5 257.6667 curveto
+112.5 263.3333 106.8333 269 101.1667 269 curveto
+101.1667 269 54.8333 269 54.8333 269 curveto
+49.1667 269 43.5 263.3333 43.5 257.6667 curveto
+43.5 257.6667 43.5 246.3333 43.5 246.3333 curveto
+43.5 240.6667 49.1667 235 54.8333 235 curveto
+stroke
+grestore
+% PAUSED->PLAYING
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 55.7749 233.7208 moveto
+50.3145 227.2701 46 219.4877 46 211 curveto
+46 211 46 211 46 106 curveto
+46 90.3829 55.6261 77.0087 67.1669 66.586 curveto
+stroke
+0 0 0 edgecolor
+newpath 69.4588 69.2327 moveto
+74.9455 60.1692 lineto
+65.0043 63.8329 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 69.4588 69.2327 moveto
+74.9455 60.1692 lineto
+65.0043 63.8329 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+46 156 moveto 26.674 (play   ) alignedtext
+grestore
+% PLAYING->PAUSED
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 103.1732 60.2267 moveto
+100.1287 80.0738 95.2127 112.7614 91.427 141 curveto
+87.6589 169.1073 83.8187 201.2839 81.2159 223.7315 curveto
+stroke
+0 0 0 edgecolor
+newpath 77.711 223.5744 moveto
+80.0433 233.9093 lineto
+84.665 224.3756 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 77.711 223.5744 moveto
+80.0433 233.9093 lineto
+84.665 224.3756 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+92 156 moveto 35.573 (pause   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/517hierarchical-issue-27-hierarchical-self-transition.eps
+++ b/test/render/fixtures/517hierarchical-issue-27-hierarchical-self-transition.eps
@@ -1,0 +1,289 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 211 162
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 211 162
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 175 126 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 124 8 124 8 curveto
+130 8 136 14 136 20 curveto
+136 20 136 78 136 78 curveto
+136 84 130 90 124 90 curveto
+124 90 20 90 20 90 curveto
+14 90 8 84 8 78 curveto
+8 78 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+53.991 71.2 moveto 36.018 (nested) alignedtext
+grestore
+% self_tr_nested_nested_1
+% nested
+% self_tr_nested_nested_1->nested
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 128 118 moveto
+122.4692 118 120.2159 110.6257 119.7834 100.2471 curveto
+stroke
+0 0 0 edgecolor
+newpath 123.285 100.0211 moveto
+119.8563 89.9964 lineto
+116.2852 99.9712 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 123.285 100.0211 moveto
+119.8563 89.9964 lineto
+116.2852 99.9712 lineto
+closepath stroke
+grestore
+% nested->self_tr_nested_nested_1
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 135.9971 35.4315 moveto
+165.1097 46.4988 162.444 118 128 118 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+151 101 moveto 16.115 (hi   ) alignedtext
+grestore
+% s
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+41 30.2 moveto 6 (s) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% s->s
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 72.0183 46.9896 moveto
+83.888 47.9685 94 43.6387 94 34 curveto
+94 27.3734 89.2205 23.2561 82.3762 21.648 curveto
+stroke
+0 0 0 edgecolor
+newpath 82.2144 18.1315 moveto
+72.0183 21.0104 lineto
+81.7843 25.1182 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 82.2144 18.1315 moveto
+72.0183 21.0104 lineto
+81.7843 25.1182 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+94 31 moveto 16.115 (hi   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/517hierarchical-issue-27-hierarchical-self-transitions.eps
+++ b/test/render/fixtures/517hierarchical-issue-27-hierarchical-self-transitions.eps
@@ -1,0 +1,355 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 388 162
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 388 162
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 352 126 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_nested
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 124 8 124 8 curveto
+130 8 136 14 136 20 curveto
+136 20 136 78 136 78 curveto
+136 84 130 90 124 90 curveto
+124 90 20 90 20 90 curveto
+14 90 8 84 8 78 curveto
+8 78 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+53.991 71.2 moveto 36.018 (nested) alignedtext
+grestore
+% self_tr_nested_nested_1
+% nested
+% self_tr_nested_nested_1->nested
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 57 118 moveto
+44.4292 118 65.9167 103.9316 77 98 curveto
+89.3631 91.3835 98.8746 97.8982 108.4711 95.2483 curveto
+stroke
+0 0 0 edgecolor
+newpath 110.3176 98.2217 moveto
+117 90 lineto
+106.649 92.26 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 110.3176 98.2217 moveto
+117 90 lineto
+106.649 92.26 lineto
+closepath stroke
+grestore
+% self_tr_nested_nested_2
+% self_tr_nested_nested_2->nested
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 128 118 moveto
+122.4692 118 120.2159 110.6257 119.7834 100.2471 curveto
+stroke
+0 0 0 edgecolor
+newpath 123.285 100.0211 moveto
+119.8563 89.9964 lineto
+116.2852 99.9712 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 123.285 100.0211 moveto
+119.8563 89.9964 lineto
+116.2852 99.9712 lineto
+closepath stroke
+grestore
+% self_tr_nested_nested_3
+% self_tr_nested_nested_3->nested
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 203 118 moveto
+186.2102 118 158.1885 80.187 141.5647 55.3012 curveto
+stroke
+0 0 0 edgecolor
+newpath 144.4083 53.2548 moveto
+135.9978 46.8116 lineto
+138.5545 57.0933 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 144.4083 53.2548 moveto
+135.9978 46.8116 lineto
+138.5545 57.0933 lineto
+closepath stroke
+grestore
+% nested->self_tr_nested_nested_1
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 117 90 moveto
+111.5039 96.8743 106.8826 94.3256 98.885 98 curveto
+80.1399 106.6122 77.6289 118 57 118 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+99 101 moveto 16.115 (hi   ) alignedtext
+grestore
+% nested->self_tr_nested_nested_2
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 135.9976 40.644 moveto
+146.1105 60.4954 143.4447 118 128 118 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+139 101 moveto 19.455 (ho   ) alignedtext
+grestore
+% nested->self_tr_nested_nested_3
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 135.9988 34.6594 moveto
+185.5194 42.5189 250.4432 118 203 118 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+219 101 moveto 125.004 (It's home from work we go   ) alignedtext
+grestore
+% s
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+41 30.2 moveto 6 (s) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% s->s
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 72.0183 46.9896 moveto
+83.888 47.9685 94 43.6387 94 34 curveto
+94 27.3734 89.2205 23.2561 82.3762 21.648 curveto
+stroke
+0 0 0 edgecolor
+newpath 82.2144 18.1315 moveto
+72.0183 21.0104 lineto
+81.7843 25.1182 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 82.2144 18.1315 moveto
+72.0183 21.0104 lineto
+81.7843 25.1182 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+94 31 moveto 16.115 (hi   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/518hierarchical-inner-outer-transitions.eps
+++ b/test/render/fixtures/518hierarchical-inner-outer-transitions.eps
@@ -1,0 +1,347 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 425 162
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 425 162
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 389 126 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_outer
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 361 8 361 8 curveto
+367 8 373 14 373 20 curveto
+373 20 373 78 373 78 curveto
+373 84 367 90 361 90 curveto
+361 90 20 90 20 90 curveto
+14 90 8 84 8 78 curveto
+8 78 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+177.329 71.2 moveto 27.342 (outer) alignedtext
+grestore
+% self_tr_outer_outer_1
+% outer
+% self_tr_outer_outer_1->outer
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 23 118 moveto
+13.7197 118 21.9816 104.0717 29 98 curveto
+44.3382 84.7306 59.5016 99.7597 74.3178 95.2644 curveto
+stroke
+0 0 0 edgecolor
+newpath 76.2638 98.1777 moveto
+83 90 lineto
+72.6344 92.192 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 76.2638 98.1777 moveto
+83 90 lineto
+72.6344 92.192 lineto
+closepath stroke
+grestore
+% self_tr_outer_outer_2
+% self_tr_outer_outer_2->outer
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 165 118 moveto
+157.2415 118 147.2544 109.5358 137.2353 97.9811 curveto
+stroke
+0 0 0 edgecolor
+newpath 139.7256 95.4991 moveto
+130.6698 89.9997 lineto
+134.3196 99.946 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 139.7256 95.4991 moveto
+130.6698 89.9997 lineto
+134.3196 99.946 lineto
+closepath stroke
+grestore
+% outer->self_tr_outer_outer_1
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 83 90 moveto
+69.7824 103.1865 58.1046 88.9753 41.76 98 curveto
+31.091 103.8909 35.1873 118 23 118 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+42 101 moveto 87.24 (external transition   ) alignedtext
+grestore
+% outer->self_tr_outer_outer_2
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 176.1196 89.9964 moveto
+184.8805 105.4198 183.9173 118 165 118 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+181 101 moveto 127.792 (explicitly external transition   ) alignedtext
+grestore
+% outer->outer
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 94.349 34.4037 moveto
+101.7881 42.7479 116 42.6133 116 34 curveto
+116 28.213 109.5845 26.2533 103.1181 28.1211 curveto
+stroke
+0 0 0 edgecolor
+newpath 100.9778 25.3312 moveto
+94.349 33.5963 lineto
+104.6851 31.2689 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 100.9778 25.3312 moveto
+94.349 33.5963 lineto
+104.6851 31.2689 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+116 31 moveto 84.459 (internal transition   ) alignedtext
+grestore
+% outer->outer
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 94.3578 34.407 moveto
+110.0953 51.4989 200.459 51.3633 200.459 34 curveto
+200.459 18.7393 130.6552 16.7865 103.0649 28.1417 curveto
+stroke
+0 0 0 edgecolor
+newpath 100.9763 25.3199 moveto
+94.3578 33.593 lineto
+104.691 31.253 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 100.9763 25.3199 moveto
+94.3578 33.593 lineto
+104.691 31.253 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+200.459 31 moveto 151.144 (internal transition/ with an action   ) alignedtext
+grestore
+% inner
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+30.665 30.2 moveto 26.67 (inner) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/519hierarchical-nested-self-transition.eps
+++ b/test/render/fixtures/519hierarchical-nested-self-transition.eps
@@ -1,0 +1,395 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 403 314
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 403 314
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 367 278 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_outer
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 254 8 254 8 curveto
+260 8 266 14 266 20 curveto
+266 20 266 218 266 218 curveto
+266 224 260 230 254 230 curveto
+254 230 20 230 20 230 curveto
+14 230 8 224 8 218 curveto
+8 218 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+123.829 211.2 moveto 27.342 (outer) alignedtext
+grestore
+% cluster_inner.two
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 28 16 moveto
+28 16 203 16 203 16 curveto
+209 16 215 22 215 28 curveto
+215 28 215 86 215 86 curveto
+215 92 209 98 203 98 curveto
+203 98 28 98 28 98 curveto
+22 98 16 92 16 86 curveto
+16 86 16 28 16 28 curveto
+16 22 22 16 28 16 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+91.1634 79.2 moveto 48.6732 (inner.two) alignedtext
+grestore
+% self_tr_outer_outer_1
+% outer
+% self_tr_outer_outer_1->outer
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 258 270 moveto
+250.0779 270 248.0395 256.7618 248.6075 240.1173 curveto
+stroke
+0 0 0 edgecolor
+newpath 252.1093 240.1907 moveto
+249.2183 229.9979 lineto
+245.122 239.7689 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 252.1093 240.1907 moveto
+249.2183 229.9979 lineto
+245.122 239.7689 lineto
+closepath stroke
+grestore
+% outer->self_tr_outer_outer_1
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 265.9965 175.2335 moveto
+300.4754 186.4251 297.8099 270 258 270 curveto
+stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+288 253 moveto 71.143 (outer => outer   ) alignedtext
+0 0 0 edgecolor
+10 /Helvetica set_font
+288 241 moveto 50.559 (\(sorta ok\)   ) alignedtext
+grestore
+% self_tr_inner.two_inner.two_3
+% inner.two
+% self_tr_inner.two_inner.two_3->inner.two
+gsave
+1 setlinewidth
+0.33333 1 0.39216 edgecolor
+newpath 236 174 moveto
+228.5059 174 221.2691 141.124 215.8992 108.1862 curveto
+stroke
+0.33333 1 0.39216 edgecolor
+newpath 219.3079 107.3321 moveto
+214.2944 97.9985 lineto
+212.3931 108.4213 lineto
+closepath fill
+1 setlinewidth
+solid
+0.33333 1 0.39216 edgecolor
+newpath 219.3079 107.3321 moveto
+214.2944 97.9985 lineto
+212.3931 108.4213 lineto
+closepath stroke
+grestore
+% inner.one
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+26.9914 170.2 moveto 50.0172 (inner.one) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 157 moveto
+28.3333 157 75.6667 157 75.6667 157 curveto
+81.3333 157 87 162.6667 87 168.3333 curveto
+87 168.3333 87 179.6667 87 179.6667 curveto
+87 185.3333 81.3333 191 75.6667 191 curveto
+75.6667 191 28.3333 191 28.3333 191 curveto
+22.6667 191 17 185.3333 17 179.6667 curveto
+17 179.6667 17 168.3333 17 168.3333 curveto
+17 162.6667 22.6667 157 28.3333 157 curveto
+stroke
+grestore
+% inner.one->inner.one
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 88.25 178.875 moveto
+100.3333 178.875 110 177.25 110 174 curveto
+110 171.7656 105.431 170.2993 98.6489 169.6011 curveto
+stroke
+0 0 0 edgecolor
+newpath 98.3996 166.0861 moveto
+88.25 169.125 lineto
+98.0794 173.0788 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 98.3996 166.0861 moveto
+88.25 169.125 lineto
+98.0794 173.0788 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+110 177 moveto 108.935 (inner.one => inner.one   ) alignedtext
+0 0 0 edgecolor
+10 /Helvetica set_font
+110 165 moveto 50.559 (\(sorta ok\)   ) alignedtext
+grestore
+% inner.two->self_tr_inner.two_inner.two_3
+gsave
+1 setlinewidth
+0.33333 1 0.39216 edgecolor
+newpath 215 50.9691 moveto
+230.1336 80.6788 248.6261 174 236 174 curveto
+stroke
+0.33333 1 0.39216 edgecolor
+10 /Helvetica set_font
+239 130 moveto 106.695 (inner.two => inner.two   ) alignedtext
+0.33333 1 0.39216 edgecolor
+10 /Helvetica set_font
+239 118 moveto 73.892 (\(slightly better\)   ) alignedtext
+grestore
+% innerst
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+34.9976 38.2 moveto 36.0048 (innerst) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 36.3333 25 moveto
+36.3333 25 69.6667 25 69.6667 25 curveto
+75.3333 25 81 30.6667 81 36.3333 curveto
+81 36.3333 81 47.6667 81 47.6667 curveto
+81 53.3333 75.3333 59 69.6667 59 curveto
+69.6667 59 36.3333 59 36.3333 59 curveto
+30.6667 59 25 53.3333 25 47.6667 curveto
+25 47.6667 25 36.3333 25 36.3333 curveto
+25 30.6667 30.6667 25 36.3333 25 curveto
+stroke
+grestore
+% innerst->innerst
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 82.0927 53.9114 moveto
+93.9763 54.658 104 50.6875 104 42 curveto
+104 36.0273 99.2622 32.2842 92.4395 30.7706 curveto
+stroke
+0 0 0 edgecolor
+newpath 92.3013 27.254 moveto
+82.0927 30.0886 lineto
+91.8408 34.2389 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 92.3013 27.254 moveto
+82.0927 30.0886 lineto
+91.8408 34.2389 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+104 45 moveto 85.581 (innerst => innerst   ) alignedtext
+0 0 0 edgecolor
+10 /Helvetica set_font
+104 33 moveto 50.559 (\(sorta ok\)   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/600kitchensink.eps
+++ b/test/render/fixtures/600kitchensink.eps
@@ -1,0 +1,649 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 420 536
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 420 536
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 384 500 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_on
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 76 111 moveto
+76 111 292 111 292 111 curveto
+298 111 304 117 304 123 curveto
+304 123 304 471.5 304 471.5 curveto
+304 477.5 298 483.5 292 483.5 curveto
+292 483.5 76 483.5 76 483.5 curveto
+70 483.5 64 477.5 64 471.5 curveto
+64 471.5 64 123 64 123 curveto
+64 117 70 111 76 111 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+177.8292 464.7 moveto 13.3416 (on) alignedtext
+grestore
+% initial
+gsave
+0 0 0 nodecolor
+28 347 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+28 347 5.5 5.5 ellipse_path stroke
+grestore
+% off
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+21.3298 279.2 moveto 13.3404 (off) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 266 moveto
+12.3333 266 43.6667 266 43.6667 266 curveto
+49.3333 266 55 271.6667 55 277.3333 curveto
+55 277.3333 55 288.6667 55 288.6667 curveto
+55 294.3333 49.3333 300 43.6667 300 curveto
+43.6667 300 12.3333 300 12.3333 300 curveto
+6.6667 300 1 294.3333 1 288.6667 curveto
+1 288.6667 1 277.3333 1 277.3333 curveto
+1 271.6667 6.6667 266 12.3333 266 curveto
+stroke
+grestore
+% initial->off
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 28 341.0938 moveto
+28 334.2931 28 322.6275 28 311.5262 curveto
+stroke
+0 0 0 edgecolor
+newpath 31.5001 311.2328 moveto
+28 301.2328 lineto
+24.5001 311.2328 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 31.5001 311.2328 moveto
+28 301.2328 lineto
+24.5001 311.2328 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+28 312 moveto 2.779 ( ) alignedtext
+grestore
+% stopped
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+82.6556 215.2 moveto 42.6888 (stopped) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 84.3333 202 moveto
+84.3333 202 123.6667 202 123.6667 202 curveto
+129.3333 202 135 207.6667 135 213.3333 curveto
+135 213.3333 135 224.6667 135 224.6667 curveto
+135 230.3333 129.3333 236 123.6667 236 curveto
+123.6667 236 84.3333 236 84.3333 236 curveto
+78.6667 236 73 230.3333 73 224.6667 curveto
+73 224.6667 73 213.3333 73 213.3333 curveto
+73 207.6667 78.6667 202 84.3333 202 curveto
+stroke
+grestore
+% off->stopped
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 49.5753 264.8314 moveto
+57.3572 258.2781 66.2772 250.7666 74.6134 243.7466 curveto
+stroke
+0 0 0 edgecolor
+newpath 76.9761 246.3327 moveto
+82.3708 237.2141 lineto
+72.4672 240.9783 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 76.9761 246.3327 moveto
+82.3708 237.2141 lineto
+72.4672 240.9783 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+72 248 moveto 35.562 (power   ) alignedtext
+grestore
+% standby
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+322.991 436.2 moveto 42.018 (standby) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 324.3333 423 moveto
+324.3333 423 363.6667 423 363.6667 423 curveto
+369.3333 423 375 428.6667 375 434.3333 curveto
+375 434.3333 375 445.6667 375 445.6667 curveto
+375 451.3333 369.3333 457 363.6667 457 curveto
+363.6667 457 324.3333 457 324.3333 457 curveto
+318.6667 457 313 451.3333 313 445.6667 curveto
+313 445.6667 313 434.3333 313 434.3333 curveto
+313 428.6667 318.6667 423 324.3333 423 curveto
+stroke
+grestore
+% broken
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+171.661 61.2 moveto 36.678 (broken) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 173.3333 48 moveto
+173.3333 48 206.6667 48 206.6667 48 curveto
+212.3333 48 218 53.6667 218 59.3333 curveto
+218 59.3333 218 70.6667 218 70.6667 curveto
+218 76.3333 212.3333 82 206.6667 82 curveto
+206.6667 82 173.3333 82 173.3333 82 curveto
+167.6667 82 162 76.3333 162 70.6667 curveto
+162 70.6667 162 59.3333 162 59.3333 curveto
+162 53.6667 167.6667 48 173.3333 48 curveto
+stroke
+grestore
+% final
+gsave
+0 0 0 nodecolor
+190 9.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+190 9.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+190 9.5 9.5 9.5 ellipse_path stroke
+grestore
+% broken->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 190 46.8272 moveto
+190 41.202 190 34.9783 190 29.2515 curveto
+stroke
+0 0 0 edgecolor
+newpath 193.5001 29.1396 moveto
+190 19.1396 lineto
+186.5001 29.1397 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 193.5001 29.1396 moveto
+190 19.1396 lineto
+186.5001 29.1397 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+190 30 moveto 2.779 ( ) alignedtext
+grestore
+% on
+% on->off
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 64.0048 359.3886 moveto
+55.675 341.7159 47.4125 324.1859 40.9076 310.3851 curveto
+stroke
+0 0 0 edgecolor
+newpath 43.9589 308.6494 moveto
+36.5294 301.0961 lineto
+37.627 311.6339 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 43.9589 308.6494 moveto
+36.5294 301.0961 lineto
+37.627 311.6339 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+75 376 moveto 35.562 (power   ) alignedtext
+grestore
+% paused
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+147.823 343.2 moveto 39.354 (paused) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 148.8333 330 moveto
+148.8333 330 185.1667 330 185.1667 330 curveto
+190.8333 330 196.5 335.6667 196.5 341.3333 curveto
+196.5 341.3333 196.5 352.6667 196.5 352.6667 curveto
+196.5 358.3333 190.8333 364 185.1667 364 curveto
+185.1667 364 148.8333 364 148.8333 364 curveto
+143.1667 364 137.5 358.3333 137.5 352.6667 curveto
+137.5 352.6667 137.5 341.3333 137.5 341.3333 curveto
+137.5 335.6667 143.1667 330 148.8333 330 curveto
+stroke
+grestore
+% on->paused
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 102.0471 439.9326 moveto
+103.3098 438.126 129.6828 400.3923 148.4295 373.5701 curveto
+stroke
+0 0 0 edgecolor
+newpath 151.3466 375.506 moveto
+154.2066 365.3044 lineto
+145.6091 371.4958 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 151.3466 375.506 moveto
+154.2066 365.3044 lineto
+145.6091 371.4958 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+134 396 moveto 89.465 (random occasions   ) alignedtext
+grestore
+% on.initial
+gsave
+0 0 0 nodecolor
+268 440 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+268 440 5.5 5.5 ellipse_path stroke
+grestore
+% on.history
+gsave
+2 setlinewidth
+filled
+0 0 0 nodecolor
+268 347 18 18 ellipse_path stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+263.6686 343.4 moveto 8.6628 (H) alignedtext
+grestore
+% on.initial->on.history
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 268 434.4609 moveto
+268 423.0203 268 396.0962 268 375.1196 curveto
+stroke
+0 0 0 edgecolor
+newpath 271.5001 375.1002 moveto
+268 365.1003 lineto
+264.5001 375.1003 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 271.5001 375.1002 moveto
+268 365.1003 lineto
+264.5001 375.1003 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+268 396 moveto 2.779 ( ) alignedtext
+grestore
+% playing
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+170.9956 133.2 moveto 38.0088 (playing) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 172.3333 120 moveto
+172.3333 120 207.6667 120 207.6667 120 curveto
+213.3333 120 219 125.6667 219 131.3333 curveto
+219 131.3333 219 142.6667 219 142.6667 curveto
+219 148.3333 213.3333 154 207.6667 154 curveto
+207.6667 154 172.3333 154 172.3333 154 curveto
+166.6667 154 161 148.3333 161 142.6667 curveto
+161 142.6667 161 131.3333 161 131.3333 curveto
+161 125.6667 166.6667 120 172.3333 120 curveto
+stroke
+grestore
+% stopped->playing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 102.8695 200.884 moveto
+103.1875 191.412 105.1009 180.1308 111.326 172 curveto
+120.8511 159.5589 135.7646 151.4382 150.0575 146.1856 curveto
+stroke
+0 0 0 edgecolor
+newpath 151.3728 149.4375 moveto
+159.7796 142.9895 lineto
+149.1866 142.7876 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 151.3728 149.4375 moveto
+159.7796 142.9895 lineto
+149.1866 142.7876 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+111 175 moveto 26.674 (play   ) alignedtext
+grestore
+% playing->broken
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 190 118.8314 moveto
+190 111.131 190 101.9743 190 93.4166 curveto
+stroke
+0 0 0 edgecolor
+newpath 193.5001 93.4132 moveto
+190 83.4133 lineto
+186.5001 93.4133 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 193.5001 93.4132 moveto
+190 83.4133 lineto
+186.5001 93.4133 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+190 94 moveto 151.177 (thing is past guarantee end date   ) alignedtext
+grestore
+% playing->stopped
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 170.9672 155.1476 moveto
+159.0644 166.4967 143.5617 181.2784 130.4702 193.761 curveto
+stroke
+0 0 0 edgecolor
+newpath 127.9083 191.3677 moveto
+123.0862 200.8015 lineto
+132.7389 196.4338 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 127.9083 191.3677 moveto
+123.0862 200.8015 lineto
+132.7389 196.4338 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+152 175 moveto 27.234 (stop   ) alignedtext
+grestore
+% playing->paused
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 188.8152 155.2551 moveto
+186.7375 185.5949 181.9835 248.2811 175 301 curveto
+174.2416 306.7255 173.2856 312.8272 172.3008 318.6522 curveto
+stroke
+0 0 0 edgecolor
+newpath 168.8193 318.2421 moveto
+170.5335 328.6973 lineto
+175.7134 319.4551 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 168.8193 318.2421 moveto
+170.5335 328.6973 lineto
+175.7134 319.4551 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+185 216 moveto 35.573 (pause   ) alignedtext
+grestore
+% paused->stopped
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 158.1073 328.9322 moveto
+147.5673 307.5176 129.89 271.6019 117.6218 246.676 curveto
+stroke
+0 0 0 edgecolor
+newpath 120.6078 244.8169 moveto
+113.0515 237.3904 lineto
+114.3273 247.9081 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 120.6078 244.8169 moveto
+113.0515 237.3904 lineto
+114.3273 247.9081 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+143 280 moveto 27.234 (stop   ) alignedtext
+grestore
+% paused->playing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 197.7094 339.5768 moveto
+224.7983 330.9798 260 313.8694 260 283 curveto
+260 283 260 283 260 178 curveto
+260 161.6715 245.6429 151.7235 229.9329 145.7259 curveto
+stroke
+0 0 0 edgecolor
+newpath 230.6857 142.2888 moveto
+220.0925 142.4803 lineto
+228.493 148.9366 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 230.6857 142.2888 moveto
+220.0925 142.4803 lineto
+228.493 148.9366 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+260 216 moveto 35.573 (pause   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/601kitchensink-with-notes.eps
+++ b/test/render/fixtures/601kitchensink-with-notes.eps
@@ -1,0 +1,576 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 573 483
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 573 483
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 537 447 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% initial
+gsave
+0 0 0 nodecolor
+426.453 433.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+426.453 433.5 5.5 5.5 ellipse_path stroke
+grestore
+% on backlog
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+397.4418 378.2 moveto 58.0224 (on backlog) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 398.7863 365 moveto
+398.7863 365 454.1197 365 454.1197 365 curveto
+459.7863 365 465.453 370.6667 465.453 376.3333 curveto
+465.453 376.3333 465.453 387.6667 465.453 387.6667 curveto
+465.453 393.3333 459.7863 399 454.1197 399 curveto
+454.1197 399 398.7863 399 398.7863 399 curveto
+393.1197 399 387.453 393.3333 387.453 387.6667 curveto
+387.453 387.6667 387.453 376.3333 387.453 376.3333 curveto
+387.453 370.6667 393.1197 365 398.7863 365 curveto
+stroke
+grestore
+% initial->on backlog
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 426.453 427.9886 moveto
+426.453 423.6293 426.453 417.1793 426.453 410.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 429.9531 410.0122 moveto
+426.453 400.0122 lineto
+422.9531 410.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 429.9531 410.0122 moveto
+426.453 400.0122 lineto
+422.9531 410.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+426.453 411 moveto 102.8 (item adds most value   ) alignedtext
+grestore
+% doing
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+131.78 301.2 moveto 29.346 (doing) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+85.1114 281.2 moveto 122.6832 (onentry/ `write unit test`) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+85.453 261.2 moveto 106.6812 (onentry/ `write code`) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+85.453 241.2 moveto 106.0212 (onexit/ `drink coffee`) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+85.453 221.2 moveto 10.0044 (...) alignedtext
+0 0 0 nodecolor
+newpath 79.453 295 moveto
+79.453 295 lineto
+213.453 295 lineto
+213.453 295 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 79.453 295 moveto
+79.453 295 lineto
+213.453 295 lineto
+213.453 295 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 92.453 213 moveto
+92.453 213 200.453 213 200.453 213 curveto
+206.453 213 212.453 219 212.453 225 curveto
+212.453 225 212.453 305 212.453 305 curveto
+212.453 311 206.453 317 200.453 317 curveto
+200.453 317 92.453 317 92.453 317 curveto
+86.453 317 80.453 311 80.453 305 curveto
+80.453 305 80.453 225 80.453 225 curveto
+80.453 219 86.453 213 92.453 213 curveto
+stroke
+grestore
+% testing
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+337.2806 126.2 moveto 35.3448 (testing) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 338.2863 113 moveto
+338.2863 113 370.6197 113 370.6197 113 curveto
+376.2863 113 381.953 118.6667 381.953 124.3333 curveto
+381.953 124.3333 381.953 135.6667 381.953 135.6667 curveto
+381.953 141.3333 376.2863 147 370.6197 147 curveto
+370.6197 147 338.2863 147 338.2863 147 curveto
+332.6197 147 326.953 141.3333 326.953 135.6667 curveto
+326.953 135.6667 326.953 124.3333 326.953 124.3333 curveto
+326.953 118.6667 332.6197 113 338.2863 113 curveto
+stroke
+grestore
+% doing->testing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 128.9605 211.9467 moveto
+126.2817 193.4299 127.8251 173.8399 140.424 160 curveto
+146.812 152.9828 216.0454 153.243 225.453 152 curveto
+255.9388 147.9721 290.2488 142.0535 315.817 137.3695 curveto
+stroke
+0 0 0 edgecolor
+newpath 316.6585 140.7733 moveto
+325.8546 135.5119 lineto
+315.3846 133.8902 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 316.6585 140.7733 moveto
+325.8546 135.5119 lineto
+315.3846 133.8902 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+140.453 179 moveto 85.029 (built & unit tested   ) alignedtext
+grestore
+% note_doing
+gsave
+0.16667 0.2 1 nodecolor
+newpath 208.859 152 moveto
+.047 152 lineto
+.047 108 lineto
+214.859 108 lineto
+214.859 146 lineto
+closepath fill
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 208.859 152 moveto
+.047 152 lineto
+.047 108 lineto
+214.859 108 lineto
+214.859 146 lineto
+closepath stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 208.859 152 moveto
+208.859 146 lineto
+stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 214.859 146 moveto
+208.859 146 lineto
+stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+8 139 moveto 154.478 (it is b.t.w possible to declare states) alignedtext
+0 0 0 nodecolor
+10 /Helvetica set_font
+8 127 moveto 198.906 (with spaces, commas or semi-colons in them) alignedtext
+0 0 0 nodecolor
+10 /Helvetica set_font
+8 115 moveto 192.691 (just wrap them in quotes "this is something") alignedtext
+grestore
+% doing->note_doing
+gsave
+1 setlinewidth
+dashed
+0 0 0 edgecolor
+newpath 125.9145 211.9273 moveto
+125.0477 209.2585 124.2213 206.6054 123.453 204 curveto
+118.397 186.854 114.1974 167.0408 111.3712 152.2334 curveto
+stroke
+grestore
+% i_note_tr_on backlog_doing_2
+% on backlog->i_note_tr_on backlog_doing_2
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 386.4139 364.666 moveto
+366.2491 355.9361 345.7743 347.072 344.5143 346.5265 curveto
+stroke
+grestore
+% testing->on backlog
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 383.2598 133.9833 moveto
+399.1531 137.8139 417.6125 145.3169 427.453 160 curveto
+467.2665 219.4061 448.8416 309.32 435.6848 354.3105 curveto
+stroke
+0 0 0 edgecolor
+newpath 432.3081 353.3846 moveto
+432.7362 363.9707 lineto
+439.0032 355.4282 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 432.3081 353.3846 moveto
+432.7362 363.9707 lineto
+439.0032 355.4282 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+442.453 329 moveto 54.468 (test not ok   ) alignedtext
+grestore
+% final
+gsave
+0 0 0 nodecolor
+354.453 70.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+354.453 70.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+354.453 70.5 9.5 9.5 ellipse_path stroke
+grestore
+% testing->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 354.453 111.8247 moveto
+354.453 105.1691 354.453 97.5977 354.453 90.7702 curveto
+stroke
+0 0 0 edgecolor
+newpath 357.9531 90.2752 moveto
+354.453 80.2752 lineto
+350.9531 90.2753 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 357.9531 90.2752 moveto
+354.453 80.2752 lineto
+350.9531 90.2753 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+354.453 91 moveto 37.792 (test ok   ) alignedtext
+grestore
+% note_final
+gsave
+0.16667 0.2 1 nodecolor
+newpath 425.875 44 moveto
+277.031 44 lineto
+277.031 0 lineto
+431.875 0 lineto
+431.875 38 lineto
+closepath fill
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 425.875 44 moveto
+277.031 44 lineto
+277.031 0 lineto
+431.875 0 lineto
+431.875 38 lineto
+closepath stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 425.875 44 moveto
+425.875 38 lineto
+stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 431.875 38 moveto
+425.875 38 lineto
+stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+284.992 31 moveto 103.341 (smcat recognizes initial) alignedtext
+0 0 0 nodecolor
+10 /Helvetica set_font
+284.992 19 moveto 108.369 (and final states by name) alignedtext
+0 0 0 nodecolor
+10 /Helvetica set_font
+284.992 7 moveto 138.922 (and renders them appropriately) alignedtext
+grestore
+% final->note_final
+gsave
+1 setlinewidth
+dashed
+0 0 0 edgecolor
+newpath 354.453 60.6853 moveto
+354.453 55.9244 354.453 49.9965 354.453 44.2229 curveto
+stroke
+grestore
+% i_note_tr_on backlog_doing_2->doing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 344.3947 346.4997 moveto
+341.9573 346.4852 263.7979 345.96 242.998 338 curveto
+233.331 334.3005 223.8097 329.322 214.736 323.6937 curveto
+stroke
+0 0 0 edgecolor
+newpath 216.4722 320.6475 moveto
+206.1835 318.1188 lineto
+212.6497 326.5117 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 216.4722 320.6475 moveto
+206.1835 318.1188 lineto
+212.6497 326.5117 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+243.453 329 moveto 64.455 (working on it   ) alignedtext
+grestore
+% note_tr_on backlog_doing_2
+gsave
+0.16667 0.2 1 nodecolor
+newpath 420.3093 204 moveto
+236.5967 204 lineto
+236.5967 160 lineto
+426.3093 160 lineto
+426.3093 198 lineto
+closepath fill
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 420.3093 204 moveto
+236.5967 204 lineto
+236.5967 160 lineto
+426.3093 160 lineto
+426.3093 198 lineto
+closepath stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 420.3093 204 moveto
+420.3093 198 lineto
+stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 426.3093 198 moveto
+420.3093 198 lineto
+stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+244.775 191 moveto 166.599 ("on backlog" was not declared above.) alignedtext
+0 0 0 nodecolor
+10 /Helvetica set_font
+244.775 179 moveto 173.356 (smcat auto-declares it with no activities) alignedtext
+0 0 0 nodecolor
+10 /Helvetica set_font
+244.775 167 moveto 103.939 (and no notes as default) alignedtext
+grestore
+% i_note_tr_on backlog_doing_2->note_tr_on backlog_doing_2
+gsave
+1 setlinewidth
+dashed
+0 0 0 edgecolor
+newpath 344.4436 346.3808 moveto
+344.1422 342.567 336.6875 248.2361 333.2096 204.228 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/700-parallel-no-states.eps
+++ b/test/render/fixtures/700-parallel-no-states.eps
@@ -1,0 +1,195 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 44 44
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 44 44
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 8 8 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/701-parallel-states-only.eps
+++ b/test/render/fixtures/701-parallel-states-only.eps
@@ -1,0 +1,252 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 232 142
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 232 142
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 196 106 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 168 8 168 8 curveto
+174 8 180 14 180 20 curveto
+180 20 180 78 180 78 curveto
+180 84 174 90 168 90 curveto
+168 90 20 90 20 90 curveto
+14 90 8 84 8 78 curveto
+8 78 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+74.6668 71.2 moveto 38.6664 (parallel) alignedtext
+grestore
+% parallel
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+118.6646 30.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 106.3333 17 moveto
+106.3333 17 137.6667 17 137.6667 17 curveto
+143.3333 17 149 22.6667 149 28.3333 curveto
+149 28.3333 149 39.6667 149 39.6667 curveto
+149 45.3333 143.3333 51 137.6667 51 curveto
+137.6667 51 106.3333 51 106.3333 51 curveto
+100.6667 51 95 45.3333 95 39.6667 curveto
+95 39.6667 95 28.3333 95 28.3333 curveto
+95 22.6667 100.6667 17 106.3333 17 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+40.6646 30.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/702-parallel-transitions-only.eps
+++ b/test/render/fixtures/702-parallel-transitions-only.eps
@@ -1,0 +1,275 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 154 224
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 154 224
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 118 188 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 90 8 90 8 curveto
+96 8 102 14 102 20 curveto
+102 20 102 160 102 160 curveto
+102 166 96 172 90 172 curveto
+90 172 20 172 20 172 curveto
+14 172 8 166 8 160 curveto
+8 160 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+35.6668 153.2 moveto 38.6664 (parallel) alignedtext
+grestore
+% parallel
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+40.6646 112.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 99 moveto
+28.3333 99 59.6667 99 59.6667 99 curveto
+65.3333 99 71 104.6667 71 110.3333 curveto
+71 110.3333 71 121.6667 71 121.6667 curveto
+71 127.3333 65.3333 133 59.6667 133 curveto
+59.6667 133 28.3333 133 28.3333 133 curveto
+22.6667 133 17 127.3333 17 121.6667 curveto
+17 121.6667 17 110.3333 17 110.3333 curveto
+17 104.6667 22.6667 99 28.3333 99 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+40.6646 30.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 44 97.8015 moveto
+44 87.3976 44 74.1215 44 62.3768 curveto
+stroke
+0 0 0 edgecolor
+newpath 47.5001 62.1476 moveto
+44 52.1476 lineto
+40.5001 62.1476 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 47.5001 62.1476 moveto
+44 52.1476 lineto
+40.5001 62.1476 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+44 72 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/703-parallel-states-and-transitions.eps
+++ b/test/render/fixtures/703-parallel-states-and-transitions.eps
@@ -1,0 +1,313 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 310 224
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 310 224
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 274 188 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 246 8 246 8 curveto
+252 8 258 14 258 20 curveto
+258 20 258 160 258 160 curveto
+258 166 252 172 246 172 curveto
+246 172 20 172 20 172 curveto
+14 172 8 166 8 160 curveto
+8 160 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+113.6668 153.2 moveto 38.6664 (parallel) alignedtext
+grestore
+% parallel
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+196.6646 112.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 184.3333 99 moveto
+184.3333 99 215.6667 99 215.6667 99 curveto
+221.3333 99 227 104.6667 227 110.3333 curveto
+227 110.3333 227 121.6667 227 121.6667 curveto
+227 127.3333 221.3333 133 215.6667 133 curveto
+215.6667 133 184.3333 133 184.3333 133 curveto
+178.6667 133 173 127.3333 173 121.6667 curveto
+173 121.6667 173 110.3333 173 110.3333 curveto
+173 104.6667 178.6667 99 184.3333 99 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+118.6646 112.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 106.3333 99 moveto
+106.3333 99 137.6667 99 137.6667 99 curveto
+143.3333 99 149 104.6667 149 110.3333 curveto
+149 110.3333 149 121.6667 149 121.6667 curveto
+149 127.3333 143.3333 133 137.6667 133 curveto
+137.6667 133 106.3333 133 106.3333 133 curveto
+100.6667 133 95 127.3333 95 121.6667 curveto
+95 121.6667 95 110.3333 95 110.3333 curveto
+95 104.6667 100.6667 99 106.3333 99 curveto
+stroke
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+41 112.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 99 moveto
+28.3333 99 59.6667 99 59.6667 99 curveto
+65.3333 99 71 104.6667 71 110.3333 curveto
+71 110.3333 71 121.6667 71 121.6667 curveto
+71 127.3333 65.3333 133 59.6667 133 curveto
+59.6667 133 28.3333 133 28.3333 133 curveto
+22.6667 133 17 127.3333 17 121.6667 curveto
+17 121.6667 17 110.3333 17 110.3333 curveto
+17 104.6667 22.6667 99 28.3333 99 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+40.6646 30.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.3333 17 moveto
+28.3333 17 59.6667 17 59.6667 17 curveto
+65.3333 17 71 22.6667 71 28.3333 curveto
+71 28.3333 71 39.6667 71 39.6667 curveto
+71 45.3333 65.3333 51 59.6667 51 curveto
+59.6667 51 28.3333 51 28.3333 51 curveto
+22.6667 51 17 45.3333 17 39.6667 curveto
+17 39.6667 17 28.3333 17 28.3333 curveto
+17 22.6667 22.6667 17 28.3333 17 curveto
+stroke
+grestore
+% c->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 44 97.8015 moveto
+44 87.3976 44 74.1215 44 62.3768 curveto
+stroke
+0 0 0 edgecolor
+newpath 47.5001 62.1476 moveto
+44 52.1476 lineto
+40.5001 62.1476 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 47.5001 62.1476 moveto
+44 52.1476 lineto
+40.5001 62.1476 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+44 72 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/704-parallel-states-and-transitions-typical-use.eps
+++ b/test/render/fixtures/704-parallel-states-and-transitions-typical-use.eps
@@ -1,0 +1,370 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 286 306
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 286 306
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 250 270 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 222 8 222 8 curveto
+228 8 234 14 234 20 curveto
+234 20 234 242 234 242 curveto
+234 248 228 254 222 254 curveto
+222 254 20 254 20 254 curveto
+14 254 8 248 8 242 curveto
+8 242 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+101.6668 235.2 moveto 38.6664 (parallel) alignedtext
+grestore
+% cluster_area1
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 132 16 moveto
+132 216 lineto
+226 216 lineto
+226 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+163.661 197.2 moveto 30.678 (area1) alignedtext
+grestore
+% cluster_area2
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 30 16 moveto
+30 216 lineto
+124 216 lineto
+124 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+61.661 197.2 moveto 30.678 (area2) alignedtext
+grestore
+% parallel
+% area1
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+164.6646 156.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 143 moveto
+152.3333 143 183.6667 143 183.6667 143 curveto
+189.3333 143 195 148.6667 195 154.3333 curveto
+195 154.3333 195 165.6667 195 165.6667 curveto
+195 171.3333 189.3333 177 183.6667 177 curveto
+183.6667 177 152.3333 177 152.3333 177 curveto
+146.6667 177 141 171.3333 141 165.6667 curveto
+141 165.6667 141 154.3333 141 154.3333 curveto
+141 148.6667 146.6667 143 152.3333 143 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+164.6646 38.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 25 moveto
+152.3333 25 183.6667 25 183.6667 25 curveto
+189.3333 25 195 30.6667 195 36.3333 curveto
+195 36.3333 195 47.6667 195 47.6667 curveto
+195 53.3333 189.3333 59 183.6667 59 curveto
+183.6667 59 152.3333 59 152.3333 59 curveto
+146.6667 59 141 53.3333 141 47.6667 curveto
+141 47.6667 141 36.3333 141 36.3333 curveto
+141 30.6667 146.6667 25 152.3333 25 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 168 141.9402 moveto
+168 136.3497 168 130.1701 168 124.5 curveto
+168 124.5 168 124.5 168 77.5 curveto
+168 75.1079 168 72.6252 168 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 171.5001 70.0597 moveto
+168 60.0598 lineto
+164.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 171.5001 70.0597 moveto
+168 60.0598 lineto
+164.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+168 98 moveto 2.779 ( ) alignedtext
+grestore
+% area2
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+63 156.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 143 moveto
+50.3333 143 81.6667 143 81.6667 143 curveto
+87.3333 143 93 148.6667 93 154.3333 curveto
+93 154.3333 93 165.6667 93 165.6667 curveto
+93 171.3333 87.3333 177 81.6667 177 curveto
+81.6667 177 50.3333 177 50.3333 177 curveto
+44.6667 177 39 171.3333 39 165.6667 curveto
+39 165.6667 39 154.3333 39 154.3333 curveto
+39 148.6667 44.6667 143 50.3333 143 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+62.6646 38.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 25 moveto
+50.3333 25 81.6667 25 81.6667 25 curveto
+87.3333 25 93 30.6667 93 36.3333 curveto
+93 36.3333 93 47.6667 93 47.6667 curveto
+93 53.3333 87.3333 59 81.6667 59 curveto
+81.6667 59 50.3333 59 50.3333 59 curveto
+44.6667 59 39 53.3333 39 47.6667 curveto
+39 47.6667 39 36.3333 39 36.3333 curveto
+39 30.6667 44.6667 25 50.3333 25 curveto
+stroke
+grestore
+% c->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 66 141.9402 moveto
+66 136.3497 66 130.1701 66 124.5 curveto
+66 124.5 66 124.5 66 77.5 curveto
+66 75.1079 66 72.6252 66 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 69.5001 70.0597 moveto
+66 60.0598 lineto
+62.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 69.5001 70.0597 moveto
+66 60.0598 lineto
+62.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+66 98 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/705-parallel-states-and-transitions-to-external-typical-use.eps
+++ b/test/render/fixtures/705-parallel-states-and-transitions-to-external-typical-use.eps
@@ -1,0 +1,429 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 286 345
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 286 345
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 250 309 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 47 moveto
+20 47 222 47 222 47 curveto
+228 47 234 53 234 59 curveto
+234 59 234 281 234 281 curveto
+234 287 228 293 222 293 curveto
+222 293 20 293 20 293 curveto
+14 293 8 287 8 281 curveto
+8 281 8 59 8 59 curveto
+8 53 14 47 20 47 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+101.6668 274.2 moveto 38.6664 (parallel) alignedtext
+grestore
+% cluster_area1
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 30 55 moveto
+30 255 lineto
+124 255 lineto
+124 55 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+61.661 236.2 moveto 30.678 (area1) alignedtext
+grestore
+% cluster_area2
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 132 55 moveto
+132 255 lineto
+226 255 lineto
+226 55 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+163.661 236.2 moveto 30.678 (area2) alignedtext
+grestore
+% final
+gsave
+0 0 0 nodecolor
+122 9.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+122 9.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+122 9.5 9.5 9.5 ellipse_path stroke
+grestore
+% parallel
+% area1
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+62.6646 195.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 182 moveto
+50.3333 182 81.6667 182 81.6667 182 curveto
+87.3333 182 93 187.6667 93 193.3333 curveto
+93 193.3333 93 204.6667 93 204.6667 curveto
+93 210.3333 87.3333 216 81.6667 216 curveto
+81.6667 216 50.3333 216 50.3333 216 curveto
+44.6667 216 39 210.3333 39 204.6667 curveto
+39 204.6667 39 193.3333 39 193.3333 curveto
+39 187.6667 44.6667 182 50.3333 182 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+73.6646 77.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 61.3333 64 moveto
+61.3333 64 92.6667 64 92.6667 64 curveto
+98.3333 64 104 69.6667 104 75.3333 curveto
+104 75.3333 104 86.6667 104 86.6667 curveto
+104 92.3333 98.3333 98 92.6667 98 curveto
+92.6667 98 61.3333 98 61.3333 98 curveto
+55.6667 98 50 92.3333 50 86.6667 curveto
+50 86.6667 50 75.3333 50 75.3333 curveto
+50 69.6667 55.6667 64 61.3333 64 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 69.5806 180.6439 moveto
+70.382 175.1523 71 169.1016 71 163.5 curveto
+71 163.5 71 163.5 71 116.5 curveto
+71 114.2146 71.1224 111.8579 71.3322 109.4969 curveto
+stroke
+0 0 0 edgecolor
+newpath 74.8359 109.7039 moveto
+72.7033 99.3259 lineto
+67.8986 108.7687 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 74.8359 109.7039 moveto
+72.7033 99.3259 lineto
+67.8986 108.7687 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+71 137 moveto 2.779 ( ) alignedtext
+grestore
+% b->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 88.3554 62.9575 moveto
+95.4439 51.6946 104.5068 37.2947 111.4402 26.2784 curveto
+stroke
+0 0 0 edgecolor
+newpath 114.5173 27.96 moveto
+116.8817 17.6323 lineto
+108.593 24.2314 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 114.5173 27.96 moveto
+116.8817 17.6323 lineto
+108.593 24.2314 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+109 30 moveto 2.779 ( ) alignedtext
+grestore
+% area2
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+165 195.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 182 moveto
+152.3333 182 183.6667 182 183.6667 182 curveto
+189.3333 182 195 187.6667 195 193.3333 curveto
+195 193.3333 195 204.6667 195 204.6667 curveto
+195 210.3333 189.3333 216 183.6667 216 curveto
+183.6667 216 152.3333 216 152.3333 216 curveto
+146.6667 216 141 210.3333 141 204.6667 curveto
+141 204.6667 141 193.3333 141 193.3333 curveto
+141 187.6667 146.6667 182 152.3333 182 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+164.6646 77.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 64 moveto
+152.3333 64 183.6667 64 183.6667 64 curveto
+189.3333 64 195 69.6667 195 75.3333 curveto
+195 75.3333 195 86.6667 195 86.6667 curveto
+195 92.3333 189.3333 98 183.6667 98 curveto
+183.6667 98 152.3333 98 152.3333 98 curveto
+146.6667 98 141 92.3333 141 86.6667 curveto
+141 86.6667 141 75.3333 141 75.3333 curveto
+141 69.6667 146.6667 64 152.3333 64 curveto
+stroke
+grestore
+% c->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 168 180.9402 moveto
+168 175.3497 168 169.1701 168 163.5 curveto
+168 163.5 168 163.5 168 116.5 curveto
+168 114.1079 168 111.6252 168 109.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 171.5001 109.0597 moveto
+168 99.0598 lineto
+164.5001 109.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 171.5001 109.0597 moveto
+168 99.0598 lineto
+164.5001 109.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+168 137 moveto 2.779 ( ) alignedtext
+grestore
+% d->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 156.3923 62.9575 moveto
+149.1462 51.6946 139.8819 37.2947 132.7945 26.2784 curveto
+stroke
+0 0 0 edgecolor
+newpath 135.5861 24.1485 moveto
+127.232 17.6323 lineto
+129.6991 27.9359 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 135.5861 24.1485 moveto
+127.232 17.6323 lineto
+129.6991 27.9359 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+140 30 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/706-parallel-states-and-transitions-from-external-typical-use.eps
+++ b/test/render/fixtures/706-parallel-states-and-transitions-from-external-typical-use.eps
@@ -1,0 +1,428 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 299 348
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 299 348
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 263 312 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 222 8 222 8 curveto
+228 8 234 14 234 20 curveto
+234 20 234 253 234 253 curveto
+234 259 228 265 222 265 curveto
+222 265 20 265 20 265 curveto
+14 265 8 259 8 253 curveto
+8 253 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+101.6668 246.2 moveto 38.6664 (parallel) alignedtext
+grestore
+% cluster_area1
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 132 16 moveto
+132 227 lineto
+226 227 lineto
+226 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+163.661 208.2 moveto 30.678 (area1) alignedtext
+grestore
+% cluster_area2
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 30 16 moveto
+30 227 lineto
+124 227 lineto
+124 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+61.661 208.2 moveto 30.678 (area2) alignedtext
+grestore
+% initial
+gsave
+0 0 0 nodecolor
+210 298.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+210 298.5 5.5 5.5 ellipse_path stroke
+grestore
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+164.6646 167.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 154 moveto
+152.3333 154 183.6667 154 183.6667 154 curveto
+189.3333 154 195 159.6667 195 165.3333 curveto
+195 165.3333 195 176.6667 195 176.6667 curveto
+195 182.3333 189.3333 188 183.6667 188 curveto
+183.6667 188 152.3333 188 152.3333 188 curveto
+146.6667 188 141 182.3333 141 176.6667 curveto
+141 176.6667 141 165.3333 141 165.3333 curveto
+141 159.6667 146.6667 154 152.3333 154 curveto
+stroke
+grestore
+% initial->a
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 208.1953 293.0215 moveto
+202.9476 277.0911 187.4234 229.9639 177.2752 199.1568 curveto
+stroke
+0 0 0 edgecolor
+newpath 180.5154 197.8063 moveto
+174.0623 189.4034 lineto
+173.8668 199.9965 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 180.5154 197.8063 moveto
+174.0623 189.4034 lineto
+173.8668 199.9965 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+204 276 moveto 2.779 ( ) alignedtext
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+175.6646 38.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 163.3333 25 moveto
+163.3333 25 194.6667 25 194.6667 25 curveto
+200.3333 25 206 30.6667 206 36.3333 curveto
+206 36.3333 206 47.6667 206 47.6667 curveto
+206 53.3333 200.3333 59 194.6667 59 curveto
+194.6667 59 163.3333 59 163.3333 59 curveto
+157.6667 59 152 53.3333 152 47.6667 curveto
+152 47.6667 152 36.3333 152 36.3333 curveto
+152 30.6667 157.6667 25 163.3333 25 curveto
+stroke
+grestore
+% initial->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 213.1345 293.9345 moveto
+217.3055 287.6698 224.6575 275.9373 229 265 curveto
+244.8713 225.0253 252 214.0102 252 171 curveto
+252 171 252 171 252 77.5 curveto
+252 68.7008 234.6302 60.0391 216.8364 53.4744 curveto
+stroke
+0 0 0 edgecolor
+newpath 217.6098 50.0376 moveto
+207.0149 50.0555 lineto
+215.3084 56.6485 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 217.6098 50.0376 moveto
+207.0149 50.0555 lineto
+215.3084 56.6485 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+252 118 moveto 2.779 ( ) alignedtext
+grestore
+% parallel
+% area1
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 171.5806 152.6439 moveto
+172.382 147.1523 173 141.1016 173 135.5 curveto
+173 135.5 173 135.5 173 77.5 curveto
+173 75.2146 173.1224 72.8579 173.3322 70.4969 curveto
+stroke
+0 0 0 edgecolor
+newpath 176.8359 70.7039 moveto
+174.7033 60.3259 lineto
+169.8986 69.7687 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 176.8359 70.7039 moveto
+174.7033 60.3259 lineto
+169.8986 69.7687 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+173 98 moveto 2.779 ( ) alignedtext
+grestore
+% area2
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+63 167.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 154 moveto
+50.3333 154 81.6667 154 81.6667 154 curveto
+87.3333 154 93 159.6667 93 165.3333 curveto
+93 165.3333 93 176.6667 93 176.6667 curveto
+93 182.3333 87.3333 188 81.6667 188 curveto
+81.6667 188 50.3333 188 50.3333 188 curveto
+44.6667 188 39 182.3333 39 176.6667 curveto
+39 176.6667 39 165.3333 39 165.3333 curveto
+39 159.6667 44.6667 154 50.3333 154 curveto
+stroke
+grestore
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+62.6646 38.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 25 moveto
+50.3333 25 81.6667 25 81.6667 25 curveto
+87.3333 25 93 30.6667 93 36.3333 curveto
+93 36.3333 93 47.6667 93 47.6667 curveto
+93 53.3333 87.3333 59 81.6667 59 curveto
+81.6667 59 50.3333 59 50.3333 59 curveto
+44.6667 59 39 53.3333 39 47.6667 curveto
+39 47.6667 39 36.3333 39 36.3333 curveto
+39 30.6667 44.6667 25 50.3333 25 curveto
+stroke
+grestore
+% c->d
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 66 152.9402 moveto
+66 147.3497 66 141.1701 66 135.5 curveto
+66 135.5 66 135.5 66 77.5 curveto
+66 75.1079 66 72.6252 66 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 69.5001 70.0597 moveto
+66 60.0598 lineto
+62.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 69.5001 70.0597 moveto
+66 60.0598 lineto
+62.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+66 98 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/707-parallel-more-parallels.eps
+++ b/test/render/fixtures/707-parallel-more-parallels.eps
@@ -1,0 +1,721 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 520 424
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 520 424
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 484 388 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_on.parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 222 8 222 8 curveto
+228 8 234 14 234 20 curveto
+234 20 234 360 234 360 curveto
+234 366 228 372 222 372 curveto
+222 372 20 372 20 372 curveto
+14 372 8 366 8 360 curveto
+8 360 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+93.8286 353.2 moveto 55.3428 (on.parallel) alignedtext
+grestore
+% cluster_on.area1
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 132 16 moveto
+132 334 lineto
+226 334 lineto
+226 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+155.8228 315.2 moveto 47.3544 (on.area1) alignedtext
+grestore
+% cluster_on.area2
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 30 16 moveto
+30 334 lineto
+124 334 lineto
+124 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+53.8228 315.2 moveto 47.3544 (on.area2) alignedtext
+grestore
+% cluster_off.parallel
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 254 8 moveto
+254 8 456 8 456 8 curveto
+462 8 468 14 468 20 curveto
+468 20 468 360 468 360 curveto
+468 366 462 372 456 372 curveto
+456 372 254 372 254 372 curveto
+248 372 242 366 242 360 curveto
+242 360 242 20 242 20 curveto
+242 14 248 8 254 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+327.8292 353.2 moveto 55.3416 (off.parallel) alignedtext
+grestore
+% cluster_off.area1
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 366 16 moveto
+366 334 lineto
+460 334 lineto
+460 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+389.8234 315.2 moveto 47.3532 (off.area1) alignedtext
+grestore
+% cluster_off.area2
+gsave
+1 setlinewidth
+dashed
+0 0 0 graphcolor
+newpath 264 16 moveto
+264 334 lineto
+358 334 lineto
+358 16 lineto
+closepath stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+287.8234 315.2 moveto 47.3532 (off.area2) alignedtext
+grestore
+% on.parallel
+% on.area1
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+164.6646 274.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 261 moveto
+152.3333 261 183.6667 261 183.6667 261 curveto
+189.3333 261 195 266.6667 195 272.3333 curveto
+195 272.3333 195 283.6667 195 283.6667 curveto
+195 289.3333 189.3333 295 183.6667 295 curveto
+183.6667 295 152.3333 295 152.3333 295 curveto
+146.6667 295 141 289.3333 141 283.6667 curveto
+141 283.6667 141 272.3333 141 272.3333 curveto
+141 266.6667 146.6667 261 152.3333 261 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+164.6646 156.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 143 moveto
+152.3333 143 183.6667 143 183.6667 143 curveto
+189.3333 143 195 148.6667 195 154.3333 curveto
+195 154.3333 195 165.6667 195 165.6667 curveto
+195 171.3333 189.3333 177 183.6667 177 curveto
+183.6667 177 152.3333 177 152.3333 177 curveto
+146.6667 177 141 171.3333 141 165.6667 curveto
+141 165.6667 141 154.3333 141 154.3333 curveto
+141 148.6667 146.6667 143 152.3333 143 curveto
+stroke
+grestore
+% a->b
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 168 259.9402 moveto
+168 254.3497 168 248.1701 168 242.5 curveto
+168 242.5 168 242.5 168 195.5 curveto
+168 193.1079 168 190.6252 168 188.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 171.5001 188.0597 moveto
+168 178.0598 lineto
+164.5001 188.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 171.5001 188.0597 moveto
+168 178.0598 lineto
+164.5001 188.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+168 216 moveto 2.779 ( ) alignedtext
+grestore
+% c
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+165 38.2 moveto 6 (c) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 152.3333 25 moveto
+152.3333 25 183.6667 25 183.6667 25 curveto
+189.3333 25 195 30.6667 195 36.3333 curveto
+195 36.3333 195 47.6667 195 47.6667 curveto
+195 53.3333 189.3333 59 183.6667 59 curveto
+183.6667 59 152.3333 59 152.3333 59 curveto
+146.6667 59 141 53.3333 141 47.6667 curveto
+141 47.6667 141 36.3333 141 36.3333 curveto
+141 30.6667 146.6667 25 152.3333 25 curveto
+stroke
+grestore
+% b->c
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 168 141.9402 moveto
+168 136.3497 168 130.1701 168 124.5 curveto
+168 124.5 168 124.5 168 77.5 curveto
+168 75.1079 168 72.6252 168 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 171.5001 70.0597 moveto
+168 60.0598 lineto
+164.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 171.5001 70.0597 moveto
+168 60.0598 lineto
+164.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+168 98 moveto 2.779 ( ) alignedtext
+grestore
+% on.area2
+% d
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+62.6646 274.2 moveto 6.6708 (d) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 261 moveto
+50.3333 261 81.6667 261 81.6667 261 curveto
+87.3333 261 93 266.6667 93 272.3333 curveto
+93 272.3333 93 283.6667 93 283.6667 curveto
+93 289.3333 87.3333 295 81.6667 295 curveto
+81.6667 295 50.3333 295 50.3333 295 curveto
+44.6667 295 39 289.3333 39 283.6667 curveto
+39 283.6667 39 272.3333 39 272.3333 curveto
+39 266.6667 44.6667 261 50.3333 261 curveto
+stroke
+grestore
+% e
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+62.6646 156.2 moveto 6.6708 (e) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 143 moveto
+50.3333 143 81.6667 143 81.6667 143 curveto
+87.3333 143 93 148.6667 93 154.3333 curveto
+93 154.3333 93 165.6667 93 165.6667 curveto
+93 171.3333 87.3333 177 81.6667 177 curveto
+81.6667 177 50.3333 177 50.3333 177 curveto
+44.6667 177 39 171.3333 39 165.6667 curveto
+39 165.6667 39 154.3333 39 154.3333 curveto
+39 148.6667 44.6667 143 50.3333 143 curveto
+stroke
+grestore
+% d->e
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 66 259.9402 moveto
+66 254.3497 66 248.1701 66 242.5 curveto
+66 242.5 66 242.5 66 195.5 curveto
+66 193.1079 66 190.6252 66 188.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 69.5001 188.0597 moveto
+66 178.0598 lineto
+62.5001 188.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 69.5001 188.0597 moveto
+66 178.0598 lineto
+62.5001 188.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+66 216 moveto 2.779 ( ) alignedtext
+grestore
+% f
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+64.3326 38.2 moveto 3.3348 (f) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 50.3333 25 moveto
+50.3333 25 81.6667 25 81.6667 25 curveto
+87.3333 25 93 30.6667 93 36.3333 curveto
+93 36.3333 93 47.6667 93 47.6667 curveto
+93 53.3333 87.3333 59 81.6667 59 curveto
+81.6667 59 50.3333 59 50.3333 59 curveto
+44.6667 59 39 53.3333 39 47.6667 curveto
+39 47.6667 39 36.3333 39 36.3333 curveto
+39 30.6667 44.6667 25 50.3333 25 curveto
+stroke
+grestore
+% e->f
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 66 141.9402 moveto
+66 136.3497 66 130.1701 66 124.5 curveto
+66 124.5 66 124.5 66 77.5 curveto
+66 75.1079 66 72.6252 66 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 69.5001 70.0597 moveto
+66 60.0598 lineto
+62.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 69.5001 70.0597 moveto
+66 60.0598 lineto
+62.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+66 98 moveto 2.779 ( ) alignedtext
+grestore
+% off.parallel
+% off.area1
+% 1
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+398.6646 274.2 moveto 6.6708 (1) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 386.3333 261 moveto
+386.3333 261 417.6667 261 417.6667 261 curveto
+423.3333 261 429 266.6667 429 272.3333 curveto
+429 272.3333 429 283.6667 429 283.6667 curveto
+429 289.3333 423.3333 295 417.6667 295 curveto
+417.6667 295 386.3333 295 386.3333 295 curveto
+380.6667 295 375 289.3333 375 283.6667 curveto
+375 283.6667 375 272.3333 375 272.3333 curveto
+375 266.6667 380.6667 261 386.3333 261 curveto
+stroke
+grestore
+% 2
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+398.6646 156.2 moveto 6.6708 (2) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 386.3333 143 moveto
+386.3333 143 417.6667 143 417.6667 143 curveto
+423.3333 143 429 148.6667 429 154.3333 curveto
+429 154.3333 429 165.6667 429 165.6667 curveto
+429 171.3333 423.3333 177 417.6667 177 curveto
+417.6667 177 386.3333 177 386.3333 177 curveto
+380.6667 177 375 171.3333 375 165.6667 curveto
+375 165.6667 375 154.3333 375 154.3333 curveto
+375 148.6667 380.6667 143 386.3333 143 curveto
+stroke
+grestore
+% 1->2
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 402 259.9402 moveto
+402 254.3497 402 248.1701 402 242.5 curveto
+402 242.5 402 242.5 402 195.5 curveto
+402 193.1079 402 190.6252 402 188.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 405.5001 188.0597 moveto
+402 178.0598 lineto
+398.5001 188.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 405.5001 188.0597 moveto
+402 178.0598 lineto
+398.5001 188.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+402 216 moveto 2.779 ( ) alignedtext
+grestore
+% 3
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+398.6646 38.2 moveto 6.6708 (3) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 386.3333 25 moveto
+386.3333 25 417.6667 25 417.6667 25 curveto
+423.3333 25 429 30.6667 429 36.3333 curveto
+429 36.3333 429 47.6667 429 47.6667 curveto
+429 53.3333 423.3333 59 417.6667 59 curveto
+417.6667 59 386.3333 59 386.3333 59 curveto
+380.6667 59 375 53.3333 375 47.6667 curveto
+375 47.6667 375 36.3333 375 36.3333 curveto
+375 30.6667 380.6667 25 386.3333 25 curveto
+stroke
+grestore
+% 2->3
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 402 141.9402 moveto
+402 136.3497 402 130.1701 402 124.5 curveto
+402 124.5 402 124.5 402 77.5 curveto
+402 75.1079 402 72.6252 402 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 405.5001 70.0597 moveto
+402 60.0598 lineto
+398.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 405.5001 70.0597 moveto
+402 60.0598 lineto
+398.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+402 98 moveto 2.779 ( ) alignedtext
+grestore
+% off.area2
+% 10
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+293.3292 274.2 moveto 13.3416 (10) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 284.3333 261 moveto
+284.3333 261 315.6667 261 315.6667 261 curveto
+321.3333 261 327 266.6667 327 272.3333 curveto
+327 272.3333 327 283.6667 327 283.6667 curveto
+327 289.3333 321.3333 295 315.6667 295 curveto
+315.6667 295 284.3333 295 284.3333 295 curveto
+278.6667 295 273 289.3333 273 283.6667 curveto
+273 283.6667 273 272.3333 273 272.3333 curveto
+273 266.6667 278.6667 261 284.3333 261 curveto
+stroke
+grestore
+% 11
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+293.3292 156.2 moveto 13.3416 (11) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 284.3333 143 moveto
+284.3333 143 315.6667 143 315.6667 143 curveto
+321.3333 143 327 148.6667 327 154.3333 curveto
+327 154.3333 327 165.6667 327 165.6667 curveto
+327 171.3333 321.3333 177 315.6667 177 curveto
+315.6667 177 284.3333 177 284.3333 177 curveto
+278.6667 177 273 171.3333 273 165.6667 curveto
+273 165.6667 273 154.3333 273 154.3333 curveto
+273 148.6667 278.6667 143 284.3333 143 curveto
+stroke
+grestore
+% 10->11
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 300 259.9402 moveto
+300 254.3497 300 248.1701 300 242.5 curveto
+300 242.5 300 242.5 300 195.5 curveto
+300 193.1079 300 190.6252 300 188.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 303.5001 188.0597 moveto
+300 178.0598 lineto
+296.5001 188.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 303.5001 188.0597 moveto
+300 178.0598 lineto
+296.5001 188.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+300 216 moveto 2.779 ( ) alignedtext
+grestore
+% 12
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+293.3292 38.2 moveto 13.3416 (12) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 284.3333 25 moveto
+284.3333 25 315.6667 25 315.6667 25 curveto
+321.3333 25 327 30.6667 327 36.3333 curveto
+327 36.3333 327 47.6667 327 47.6667 curveto
+327 53.3333 321.3333 59 315.6667 59 curveto
+315.6667 59 284.3333 59 284.3333 59 curveto
+278.6667 59 273 53.3333 273 47.6667 curveto
+273 47.6667 273 36.3333 273 36.3333 curveto
+273 30.6667 278.6667 25 284.3333 25 curveto
+stroke
+grestore
+% 11->12
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 300 141.9402 moveto
+300 136.3497 300 130.1701 300 124.5 curveto
+300 124.5 300 124.5 300 77.5 curveto
+300 75.1079 300 72.6252 300 70.1342 curveto
+stroke
+0 0 0 edgecolor
+newpath 303.5001 70.0597 moveto
+300 60.0598 lineto
+296.5001 70.0598 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 303.5001 70.0597 moveto
+300 60.0598 lineto
+296.5001 70.0598 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+300 98 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/801-labels-one-state-composite-with-activities.eps
+++ b/test/render/fixtures/801-labels-one-state-composite-with-activities.eps
@@ -1,0 +1,407 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 395 326
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 395 326
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 359 290 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_set
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 20 8 moveto
+20 8 331 8 331 8 curveto
+337 8 343 14 343 20 curveto
+343 20 343 262 343 262 curveto
+343 268 337 274 331 274 curveto
+331 274 20 274 20 274 curveto
+14 274 8 268 8 262 curveto
+8 262 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+150.8328 255.2 moveto 49.3344 (alarm set) alignedtext
+0 0 0 graphcolor
+12 /Helvetica set_font
+136.1646 235.2 moveto 78.6708 (some activities) alignedtext
+0 0 0 graphcolor
+newpath 132.5 249 moveto
+132.5 249 lineto
+218.5 249 lineto
+218.5 249 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 graphcolor
+newpath 132.5 249 moveto
+132.5 249 lineto
+218.5 249 lineto
+218.5 249 lineto
+closepath stroke
+grestore
+% set
+% silent
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+259.999 194.2 moveto 28.002 (silent) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 258.3333 181 moveto
+258.3333 181 289.6667 181 289.6667 181 curveto
+295.3333 181 301 186.6667 301 192.3333 curveto
+301 192.3333 301 203.6667 301 203.6667 curveto
+301 209.3333 295.3333 215 289.6667 215 curveto
+289.6667 215 258.3333 215 258.3333 215 curveto
+252.6667 215 247 209.3333 247 203.6667 curveto
+247 203.6667 247 192.3333 247 192.3333 curveto
+247 186.6667 252.6667 181 258.3333 181 curveto
+stroke
+grestore
+% ringing
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+157.9982 112.2 moveto 36.0036 (ringing) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 159.3333 99 moveto
+159.3333 99 192.6667 99 192.6667 99 curveto
+198.3333 99 204 104.6667 204 110.3333 curveto
+204 110.3333 204 121.6667 204 121.6667 curveto
+204 127.3333 198.3333 133 192.6667 133 curveto
+192.6667 133 159.3333 133 159.3333 133 curveto
+153.6667 133 148 127.3333 148 121.6667 curveto
+148 121.6667 148 110.3333 148 110.3333 curveto
+148 104.6667 153.6667 99 159.3333 99 curveto
+stroke
+grestore
+% silent->ringing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 245.8137 193.5889 moveto
+214.4236 188.0333 166.6618 177.4386 155.881 163 curveto
+151.427 157.0347 152.0512 149.9331 154.9042 143.0801 curveto
+stroke
+0 0 0 edgecolor
+newpath 158.1376 144.465 moveto
+159.9085 134.0192 lineto
+152.0101 141.0807 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 158.1376 144.465 moveto
+159.9085 134.0192 lineto
+152.0101 141.0807 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+155 154 moveto 91.119 (time >= alarm time   ) alignedtext
+grestore
+% ringing->silent
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 205.1252 125.4204 moveto
+219.3227 131.1143 235.8993 139.5221 248 151 curveto
+253.7677 156.4708 258.5772 163.51 262.4272 170.4663 curveto
+stroke
+0 0 0 edgecolor
+newpath 259.4698 172.3768 moveto
+267.0822 179.7458 lineto
+265.7267 169.238 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 259.4698 172.3768 moveto
+267.0822 179.7458 lineto
+265.7267 169.238 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+257 154 moveto 19.454 (off   ) alignedtext
+grestore
+% snoozing
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+188.9916 30.2 moveto 48.0168 (snoozing) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 190.3333 17 moveto
+190.3333 17 235.6667 17 235.6667 17 curveto
+241.3333 17 247 22.6667 247 28.3333 curveto
+247 28.3333 247 39.6667 247 39.6667 curveto
+247 45.3333 241.3333 51 235.6667 51 curveto
+235.6667 51 190.3333 51 190.3333 51 curveto
+184.6667 51 179 45.3333 179 39.6667 curveto
+179 39.6667 179 28.3333 179 28.3333 curveto
+179 22.6667 184.6667 17 190.3333 17 curveto
+stroke
+grestore
+% ringing->snoozing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 146.831 114.6442 moveto
+103.2251 111.5417 28.8004 101.4552 54.858 69 curveto
+68.8152 51.6161 126.1518 42.3395 167.7763 37.7963 curveto
+stroke
+0 0 0 edgecolor
+newpath 168.3972 41.2509 moveto
+177.9843 36.7412 lineto
+167.6774 34.288 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 168.3972 41.2509 moveto
+177.9843 36.7412 lineto
+167.6774 34.288 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+54 72 moveto 131.142 (snooze time := time + 9 min   ) alignedtext
+grestore
+% snoozing->silent
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 248.2377 38.8725 moveto
+266.6532 43.4052 287.6637 52.1472 299 69 curveto
+319.5015 99.478 304.3235 142.649 290.238 170.489 curveto
+stroke
+0 0 0 edgecolor
+newpath 286.9704 169.1791 moveto
+285.3617 179.6511 lineto
+293.1497 172.4679 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 286.9704 169.1791 moveto
+285.3617 179.6511 lineto
+293.1497 172.4679 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+308 113 moveto 19.454 (off   ) alignedtext
+grestore
+% snoozing->ringing
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 204.8115 52.1476 moveto
+199.9777 62.8603 193.7639 76.6314 188.3452 88.6404 curveto
+stroke
+0 0 0 edgecolor
+newpath 185.1342 87.247 moveto
+184.2115 97.8015 lineto
+191.5147 90.126 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 185.1342 87.247 moveto
+184.2115 97.8015 lineto
+191.5147 90.126 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+196 72 moveto 98.36 (time >= snooze time   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/801-labels-one-state-with-activities.eps
+++ b/test/render/fixtures/801-labels-one-state-with-activities.eps
@@ -1,0 +1,231 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 125 90
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 125 90
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 89 54 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% unset
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.3272 29.2 moveto 69.3456 (alarm not set) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+6.3314 9.2 moveto 69.3372 (some activity) alignedtext
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+81.5 23 lineto
+81.5 23 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 nodecolor
+newpath .5 23 moveto
+.5 23 lineto
+81.5 23 lineto
+81.5 23 lineto
+closepath stroke
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 13 1 moveto
+13 1 68 1 68 1 curveto
+74 1 80 7 80 13 curveto
+80 13 80 33 80 33 curveto
+80 39 74 45 68 45 curveto
+68 45 13 45 13 45 curveto
+7 45 1 39 1 33 curveto
+1 33 1 13 1 13 curveto
+1 7 7 1 13 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/801-labels-one-state.eps
+++ b/test/render/fixtures/801-labels-one-state.eps
@@ -1,0 +1,214 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 135 80
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 135 80
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 99 44 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% unset
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+11.3272 14.2 moveto 69.3456 (alarm not set) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 78.6667 1 78.6667 1 curveto
+84.3333 1 90 6.6667 90 12.3333 curveto
+90 12.3333 90 23.6667 90 23.6667 curveto
+90 29.3333 84.3333 35 78.6667 35 curveto
+78.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/802-colors-toverbal.eps
+++ b/test/render/fixtures/802-colors-toverbal.eps
@@ -1,0 +1,503 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 417 394
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 417 394
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 381 358 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_on
+gsave
+2 setlinewidth
+0 0 0.46667 graphcolor
+newpath 20 8 moveto
+20 8 157 8 157 8 curveto
+163 8 169 14 169 20 curveto
+169 20 169 310 169 310 curveto
+169 316 163 322 157 322 curveto
+157 322 20 322 20 322 curveto
+14 322 8 316 8 310 curveto
+8 310 8 20 8 20 curveto
+8 14 14 8 20 8 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+82.3292 303.2 moveto 13.3416 (on) alignedtext
+grestore
+% self_tr_on_on_3
+% on
+% self_tr_on_on_3->on
+gsave
+1 setlinewidth
+0.66667 1 1 edgecolor
+newpath 160 350 moveto
+148.9384 350 144.519 342.6267 143.7771 332.2491 curveto
+stroke
+0.66667 1 1 edgecolor
+newpath 147.2824 332.0873 moveto
+144.0445 321.9994 lineto
+140.2848 331.9047 lineto
+closepath fill
+1 setlinewidth
+solid
+0.66667 1 1 edgecolor
+newpath 147.2824 332.0873 moveto
+144.0445 321.9994 lineto
+140.2848 331.9047 lineto
+closepath stroke
+grestore
+% initial
+gsave
+0 0 0.33333 nodecolor
+300 266 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0.33333 nodecolor
+300 266 5.5 5.5 ellipse_path stroke
+grestore
+% off
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+204.3298 186.2 moveto 13.3404 (off) alignedtext
+2 setlinewidth
+solid
+0 0 0.75294 nodecolor
+newpath 195.3333 173 moveto
+195.3333 173 226.6667 173 226.6667 173 curveto
+232.3333 173 238 178.6667 238 184.3333 curveto
+238 184.3333 238 195.6667 238 195.6667 curveto
+238 201.3333 232.3333 207 226.6667 207 curveto
+226.6667 207 195.3333 207 195.3333 207 curveto
+189.6667 207 184 201.3333 184 195.6667 curveto
+184 195.6667 184 184.3333 184 184.3333 curveto
+184 178.6667 189.6667 173 195.3333 173 curveto
+stroke
+grestore
+% initial->off
+gsave
+1 setlinewidth
+0.96863 0.24706 1 edgecolor
+newpath 298.5354 260.566 moveto
+295.5527 250.4677 287.8554 228.6853 274 216 curveto
+266.7456 209.3582 257.5599 204.2884 248.462 200.47 curveto
+stroke
+0.96863 0.24706 1 edgecolor
+newpath 249.6891 197.1922 moveto
+239.0975 196.9303 lineto
+247.2141 203.74 lineto
+closepath fill
+1 setlinewidth
+solid
+0.96863 0.24706 1 edgecolor
+newpath 249.6891 197.1922 moveto
+239.0975 196.9303 lineto
+247.2141 203.74 lineto
+closepath stroke
+0.96863 0.24706 1 edgecolor
+10 /Helvetica set_font
+290 225 moveto 82.79 (regular transition   ) alignedtext
+grestore
+% yellow
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+96.335 45.2 moveto 33.33 (yellow) alignedtext
+0 0 0 nodecolor
+12 /Helvetica set_font
+70.9976 25.2 moveto 84.0048 ([first entry] blink) alignedtext
+0.10588 1 1 nodecolor
+newpath 65 39 moveto
+65 39 lineto
+161 39 lineto
+161 39 lineto
+closepath fill
+1 setlinewidth
+solid
+0.10588 1 1 nodecolor
+newpath 65 39 moveto
+65 39 lineto
+161 39 lineto
+161 39 lineto
+closepath stroke
+2 setlinewidth
+solid
+0.10588 1 1 nodecolor
+newpath 78 17 moveto
+78 17 148 17 148 17 curveto
+154 17 160 23 160 29 curveto
+160 29 160 49 160 49 curveto
+160 55 154 61 148 61 curveto
+148 61 78 61 78 61 curveto
+72 61 66 55 66 49 curveto
+66 49 66 29 66 29 curveto
+66 23 72 17 78 17 curveto
+stroke
+grestore
+% off->yellow
+gsave
+1 setlinewidth
+0.33333 1 1 edgecolor
+newpath 199.6331 171.8427 moveto
+190.5945 157.4591 177.5875 136.8804 166 119 curveto
+155.6454 103.0222 143.9737 85.3671 134.2242 70.7163 curveto
+stroke
+0.33333 1 1 edgecolor
+newpath 136.8895 68.4044 moveto
+128.4312 62.0242 lineto
+131.0647 72.2866 lineto
+closepath fill
+1 setlinewidth
+solid
+0.33333 1 1 edgecolor
+newpath 136.8895 68.4044 moveto
+128.4312 62.0242 lineto
+131.0647 72.2866 lineto
+closepath stroke
+0.33333 1 1 edgecolor
+10 /Helvetica set_font
+160 102 moveto 133.38 (transition into a nested state   ) alignedtext
+grestore
+% on->self_tr_on_on_3
+gsave
+1 setlinewidth
+0.66667 1 1 edgecolor
+newpath 168.9979 267.4381 moveto
+197.9622 278.5272 194.4396 350 160 350 curveto
+stroke
+0.66667 1 1 edgecolor
+10 /Helvetica set_font
+183 333 moveto 140.031 (composite state self transition   ) alignedtext
+grestore
+% on->off
+gsave
+1 setlinewidth
+0 1 1 edgecolor
+newpath 168.9977 248.9099 moveto
+173.9433 238.9745 180.7209 226.4021 187.987 216 curveto
+188.0453 215.9166 188.1037 215.8332 188.1624 215.7497 curveto
+stroke
+0 1 1 edgecolor
+newpath 190.7774 218.0904 moveto
+194.1087 208.0329 lineto
+185.2325 213.8178 lineto
+closepath fill
+1 setlinewidth
+solid
+0 1 1 edgecolor
+newpath 190.7774 218.0904 moveto
+194.1087 208.0329 lineto
+185.2325 213.8178 lineto
+closepath stroke
+0 1 1 edgecolor
+10 /Helvetica set_font
+187 231 moveto 85.013 (from a composite   ) alignedtext
+0 1 1 edgecolor
+10 /Helvetica set_font
+187 219 moveto 83.36 (to a regular state   ) alignedtext
+grestore
+% red
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+69.3318 262.2 moveto 17.3364 (red) alignedtext
+2 setlinewidth
+solid
+0.33333 1 0.39216 nodecolor
+newpath 62.3333 249 moveto
+62.3333 249 93.6667 249 93.6667 249 curveto
+99.3333 249 105 254.6667 105 260.3333 curveto
+105 260.3333 105 271.6667 105 271.6667 curveto
+105 277.3333 99.3333 283 93.6667 283 curveto
+93.6667 283 62.3333 283 62.3333 283 curveto
+56.6667 283 51 277.3333 51 271.6667 curveto
+51 271.6667 51 260.3333 51 260.3333 curveto
+51 254.6667 56.6667 249 62.3333 249 curveto
+stroke
+grestore
+% green
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+28.661 133.2 moveto 30.678 (green) alignedtext
+2 setlinewidth
+solid
+0.33333 1 1 nodecolor
+newpath 28.3333 120 moveto
+28.3333 120 59.6667 120 59.6667 120 curveto
+65.3333 120 71 125.6667 71 131.3333 curveto
+71 131.3333 71 142.6667 71 142.6667 curveto
+71 148.3333 65.3333 154 59.6667 154 curveto
+59.6667 154 28.3333 154 28.3333 154 curveto
+22.6667 154 17 148.3333 17 142.6667 curveto
+17 142.6667 17 131.3333 17 131.3333 curveto
+17 125.6667 22.6667 120 28.3333 120 curveto
+stroke
+grestore
+% red->green
+gsave
+1 setlinewidth
+0.76863 0.86667 0.94118 edgecolor
+newpath 69.7368 247.7927 moveto
+64.9192 236.5315 59.0791 221.6641 55.365 208 curveto
+51.6046 194.1657 48.9309 178.455 47.1257 165.3357 curveto
+stroke
+0.76863 0.86667 0.94118 edgecolor
+newpath 50.5474 164.499 moveto
+45.8088 155.0229 lineto
+43.6037 165.3858 lineto
+closepath fill
+1 setlinewidth
+solid
+0.76863 0.86667 0.94118 edgecolor
+newpath 50.5474 164.499 moveto
+45.8088 155.0229 lineto
+43.6037 165.3858 lineto
+closepath stroke
+0.76863 0.86667 0.94118 edgecolor
+10 /Helvetica set_font
+56 199 moveto 98.635 ([t > 2min]: transition    ) alignedtext
+0.76863 0.86667 0.94118 edgecolor
+10 /Helvetica set_font
+56 187 moveto 93.92 (from a nested state   ) alignedtext
+0.76863 0.86667 0.94118 edgecolor
+10 /Helvetica set_font
+56 175 moveto 82.262 (to a nested state   ) alignedtext
+grestore
+% yellow->red
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 112.4605 62.14 moveto
+111.9191 93.7868 111.7762 147.5195 116.811 155 curveto
+127.1846 170.4128 144.8809 156.419 155 172 curveto
+163.7146 185.4185 162.1406 193.6818 155 208 curveto
+146.5086 225.027 130.3733 238.3695 115.0581 247.942 curveto
+stroke
+0 0 0 edgecolor
+newpath 113.0517 245.0612 moveto
+106.1994 253.1419 lineto
+116.5952 251.0981 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 113.0517 245.0612 moveto
+106.1994 253.1419 lineto
+116.5952 251.0981 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+116 134 moveto 44.189 ([t > 10s]   ) alignedtext
+grestore
+% green->yellow
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 46.4469 118.749 moveto
+48.7527 106.6474 53.1245 90.8714 61.263 79 curveto
+63.6463 75.5235 66.4265 72.2141 69.4382 69.0964 curveto
+stroke
+0 0 0 edgecolor
+newpath 71.9104 71.5763 moveto
+76.8082 62.1815 lineto
+67.1207 66.4715 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 71.9104 71.5763 moveto
+76.8082 62.1815 lineto
+67.1207 66.4715 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+62 82 moveto 49.737 ([t > 2min]   ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/803active-and-inactive.eps
+++ b/test/render/fixtures/803active-and-inactive.eps
@@ -1,0 +1,665 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 298 368
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 298 368
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 262 332 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% cluster_composite.active
+gsave
+3 setlinewidth
+0 0 0 graphcolor
+newpath 20 139 moveto
+20 139 118 139 118 139 curveto
+124 139 130 145 130 151 curveto
+130 151 130 209 130 209 curveto
+130 215 124 221 118 221 curveto
+118 221 20 221 20 221 curveto
+14 221 8 215 8 209 curveto
+8 209 8 151 8 151 curveto
+8 145 14 139 20 139 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+24.8252 203.2 moveto 89.3496 (composite.active) alignedtext
+grestore
+% cluster_composite
+gsave
+2 setlinewidth
+0 0 0 graphcolor
+newpath 150 139 moveto
+150 139 220 139 220 139 curveto
+226 139 232 145 232 151 curveto
+232 151 232 209 232 209 curveto
+232 215 226 221 220 221 curveto
+220 221 150 221 150 221 curveto
+144 221 138 215 138 209 curveto
+138 209 138 151 138 151 curveto
+138 145 144 139 150 139 curveto
+stroke
+0 0 0 graphcolor
+12 /Helvetica set_font
+157.6622 202.2 moveto 54.6756 (composite) alignedtext
+grestore
+% initial.active
+gsave
+0 0 0 nodecolor
+122 318.5 5.5 5.5 ellipse_path fill
+3 setlinewidth
+filled
+0 0 0 nodecolor
+122 318.5 5.5 5.5 ellipse_path stroke
+grestore
+% regular.active
+gsave
+2 setlinewidth
+0 0 0 nodecolor
+newpath 157 285 moveto
+157 285 87 285 87 285 curveto
+81 285 75 279 75 273 curveto
+75 273 75 261 75 261 curveto
+75 255 81 249 87 249 curveto
+87 249 157 249 157 249 curveto
+163 249 169 255 169 261 curveto
+169 261 169 273 169 273 curveto
+169 279 163 285 157 285 curveto
+stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+85.9952 264.2 moveto 72.0096 (regular.active) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 87.3333 250 moveto
+87.3333 250 156.6667 250 156.6667 250 curveto
+162.3333 250 168 255.6667 168 261.3333 curveto
+168 261.3333 168 272.6667 168 272.6667 curveto
+168 278.3333 162.3333 284 156.6667 284 curveto
+156.6667 284 87.3333 284 87.3333 284 curveto
+81.6667 284 76 278.3333 76 272.6667 curveto
+76 272.6667 76 261.3333 76 261.3333 curveto
+76 255.6667 81.6667 250 87.3333 250 curveto
+stroke
+grestore
+% initial.active->regular.active
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 122 312.9886 moveto
+122 308.6293 122 302.1793 122 295.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 125.5001 295.0122 moveto
+122 285.0122 lineto
+118.5001 295.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 125.5001 295.0122 moveto
+122 285.0122 lineto
+118.5001 295.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+122 296 moveto 2.779 ( ) alignedtext
+grestore
+% initial
+gsave
+0 0 0 nodecolor
+224 318.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+224 318.5 5.5 5.5 ellipse_path stroke
+grestore
+% regular
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+205.8322 263.2 moveto 37.3356 (regular) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 206.8333 250 moveto
+206.8333 250 241.1667 250 241.1667 250 curveto
+246.8333 250 252.5 255.6667 252.5 261.3333 curveto
+252.5 261.3333 252.5 272.6667 252.5 272.6667 curveto
+252.5 278.3333 246.8333 284 241.1667 284 curveto
+241.1667 284 206.8333 284 206.8333 284 curveto
+201.1667 284 195.5 278.3333 195.5 272.6667 curveto
+195.5 272.6667 195.5 261.3333 195.5 261.3333 curveto
+195.5 255.6667 201.1667 250 206.8333 250 curveto
+stroke
+grestore
+% initial->regular
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 224 312.9886 moveto
+224 308.6293 224 302.1793 224 295.4801 curveto
+stroke
+0 0 0 edgecolor
+newpath 227.5001 295.0122 moveto
+224 285.0122 lineto
+220.5001 295.0122 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 227.5001 295.0122 moveto
+224 285.0122 lineto
+220.5001 295.0122 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+224 296 moveto 2.779 ( ) alignedtext
+grestore
+% composite.active
+% regular.active->composite.active
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 122 248.7644 moveto
+122 243.5522 122 237.5482 122 231.1982 curveto
+stroke
+0 0 0 edgecolor
+newpath 125.5001 230.999 moveto
+122 220.999 lineto
+118.5001 230.999 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 125.5001 230.999 moveto
+122 220.999 lineto
+118.5001 230.999 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+122 232 moveto 2.779 ( ) alignedtext
+grestore
+% composite
+% regular->composite
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 224 248.7644 moveto
+224 243.5522 224 237.5482 224 231.1982 curveto
+stroke
+0 0 0 edgecolor
+newpath 227.5001 230.999 moveto
+224 220.999 lineto
+220.5001 230.999 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 227.5001 230.999 moveto
+224 220.999 lineto
+220.5001 230.999 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+224 232 moveto 2.779 ( ) alignedtext
+grestore
+% ^choice.active
+gsave
+3 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 58 111 moveto
+45.5 98.5 lineto
+58 86 lineto
+70.5 98.5 lineto
+closepath stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+56.6105 95.5 moveto 2.779 ( ) alignedtext
+grestore
+% ^choice.active->^choice.active
+gsave
+0 0 0 edgecolor
+10 /Helvetica set_font
+92.5 96.5 moveto 28.896 (choice) alignedtext
+grestore
+% ]forkjoin.active
+gsave
+0 0 0 nodecolor
+58 52.5 5.5 5.5 ellipse_path fill
+3 setlinewidth
+filled
+0 0 0 nodecolor
+58 52.5 5.5 5.5 ellipse_path stroke
+grestore
+% ^choice.active->]forkjoin.active
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 58 85.9303 moveto
+58 80.6234 58 74.3765 58 68.728 curveto
+stroke
+0 0 0 edgecolor
+newpath 61.5001 68.4665 moveto
+58 58.4665 lineto
+54.5001 68.4666 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 61.5001 68.4665 moveto
+58 58.4665 lineto
+54.5001 68.4666 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 69 moveto 2.779 ( ) alignedtext
+grestore
+% ^choice
+gsave
+2 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 174 111 moveto
+161.5 98.5 lineto
+174 86 lineto
+186.5 98.5 lineto
+closepath stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+172.6105 95.5 moveto 2.779 ( ) alignedtext
+grestore
+% ^choice->^choice
+gsave
+0 0 0 edgecolor
+10 /Helvetica set_font
+208.5 95.5 moveto 28.896 (choice) alignedtext
+grestore
+% ]forkjoin
+gsave
+0 0 0 nodecolor
+174 52.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+174 52.5 5.5 5.5 ellipse_path stroke
+grestore
+% ^choice->]forkjoin
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 174 85.9303 moveto
+174 80.6234 174 74.3765 174 68.728 curveto
+stroke
+0 0 0 edgecolor
+newpath 177.5001 68.4665 moveto
+174 58.4665 lineto
+170.5001 68.4666 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 177.5001 68.4665 moveto
+174 58.4665 lineto
+170.5001 68.4666 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+174 69 moveto 2.779 ( ) alignedtext
+grestore
+% final.active
+gsave
+0 0 0 nodecolor
+58 9.5 5.5 5.5 ellipse_path fill
+3 setlinewidth
+filled
+0 0 0 nodecolor
+58 9.5 5.5 5.5 ellipse_path stroke
+3 setlinewidth
+filled
+0 0 0 nodecolor
+58 9.5 9.5 9.5 ellipse_path stroke
+grestore
+% ]forkjoin.active->final.active
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 58 46.8785 moveto
+58 42.3867 58 35.8057 58 29.4129 curveto
+stroke
+0 0 0 edgecolor
+newpath 61.5001 29.2338 moveto
+58 19.2339 lineto
+54.5001 29.2339 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 61.5001 29.2338 moveto
+58 19.2339 lineto
+54.5001 29.2339 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 30 moveto 2.779 ( ) alignedtext
+grestore
+% final
+gsave
+0 0 0 nodecolor
+174 9.5 5.5 5.5 ellipse_path fill
+2 setlinewidth
+filled
+0 0 0 nodecolor
+174 9.5 5.5 5.5 ellipse_path stroke
+2 setlinewidth
+filled
+0 0 0 nodecolor
+174 9.5 9.5 9.5 ellipse_path stroke
+grestore
+% ]forkjoin->final
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 174 46.8785 moveto
+174 42.3867 174 35.8057 174 29.4129 curveto
+stroke
+0 0 0 edgecolor
+newpath 177.5001 29.2338 moveto
+174 19.2339 lineto
+170.5001 29.2339 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 177.5001 29.2338 moveto
+174 19.2339 lineto
+170.5001 29.2339 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+174 30 moveto 2.779 ( ) alignedtext
+grestore
+% inner.active
+gsave
+2 setlinewidth
+0 0 0 nodecolor
+newpath 87.5 183 moveto
+87.5 183 28.5 183 28.5 183 curveto
+22.5 183 16.5 177 16.5 171 curveto
+16.5 171 16.5 159 16.5 159 curveto
+16.5 153 22.5 147 28.5 147 curveto
+28.5 147 87.5 147 87.5 147 curveto
+93.5 147 99.5 153 99.5 159 curveto
+99.5 159 99.5 171 99.5 171 curveto
+99.5 177 93.5 183 87.5 183 curveto
+stroke
+0 0 0 nodecolor
+12 /Helvetica set_font
+27.828 162.2 moveto 61.344 (inner.active) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 28.8333 148 moveto
+28.8333 148 87.1667 148 87.1667 148 curveto
+92.8333 148 98.5 153.6667 98.5 159.3333 curveto
+98.5 159.3333 98.5 170.6667 98.5 170.6667 curveto
+98.5 176.3333 92.8333 182 87.1667 182 curveto
+87.1667 182 28.8333 182 28.8333 182 curveto
+23.1667 182 17.5 176.3333 17.5 170.6667 curveto
+17.5 170.6667 17.5 159.3333 17.5 159.3333 curveto
+17.5 153.6667 23.1667 148 28.8333 148 curveto
+stroke
+grestore
+% inner.active->^choice.active
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 58 146.8286 moveto
+58 139.0208 58 129.8058 58 121.5272 curveto
+stroke
+0 0 0 edgecolor
+newpath 61.5001 121.381 moveto
+58 111.381 lineto
+54.5001 121.381 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 61.5001 121.381 moveto
+58 111.381 lineto
+54.5001 121.381 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+58 122 moveto 2.779 ( ) alignedtext
+grestore
+% inner
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+160.665 161.2 moveto 26.67 (inner) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 158.3333 148 moveto
+158.3333 148 189.6667 148 189.6667 148 curveto
+195.3333 148 201 153.6667 201 159.3333 curveto
+201 159.3333 201 170.6667 201 170.6667 curveto
+201 176.3333 195.3333 182 189.6667 182 curveto
+189.6667 182 158.3333 182 158.3333 182 curveto
+152.6667 182 147 176.3333 147 170.6667 curveto
+147 170.6667 147 159.3333 147 159.3333 curveto
+147 153.6667 152.6667 148 158.3333 148 curveto
+stroke
+grestore
+% inner->^choice
+gsave
+1 setlinewidth
+0 0 0 edgecolor
+newpath 174 146.8286 moveto
+174 139.0208 174 129.8058 174 121.5272 curveto
+stroke
+0 0 0 edgecolor
+newpath 177.5001 121.381 moveto
+174 111.381 lineto
+170.5001 121.381 lineto
+closepath fill
+1 setlinewidth
+solid
+0 0 0 edgecolor
+newpath 177.5001 121.381 moveto
+174 111.381 lineto
+170.5001 121.381 lineto
+closepath stroke
+0 0 0 edgecolor
+10 /Helvetica set_font
+174 122 moveto 2.779 ( ) alignedtext
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/fixtures/804lines-edge-remains-colored-when-note-attached.eps
+++ b/test/render/fixtures/804lines-edge-remains-colored-when-note-attached.eps
@@ -1,0 +1,308 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Creator: graphviz version 2.40.1 (20161225.0304)
+%%Title: state transitions
+%%Pages: 1
+%%BoundingBox: 36 36 304 161
+%%EndComments
+save
+%%BeginProlog
+/DotDict 200 dict def
+DotDict begin
+
+/setupLatin1 {
+mark
+/EncodingVector 256 array def
+ EncodingVector 0
+
+ISOLatin1Encoding 0 255 getinterval putinterval
+EncodingVector 45 /hyphen put
+
+% Set up ISO Latin 1 character encoding
+/starnetISO {
+        dup dup findfont dup length dict begin
+        { 1 index /FID ne { def }{ pop pop } ifelse
+        } forall
+        /Encoding EncodingVector def
+        currentdict end definefont
+} def
+/Times-Roman starnetISO def
+/Times-Italic starnetISO def
+/Times-Bold starnetISO def
+/Times-BoldItalic starnetISO def
+/Helvetica starnetISO def
+/Helvetica-Oblique starnetISO def
+/Helvetica-Bold starnetISO def
+/Helvetica-BoldOblique starnetISO def
+/Courier starnetISO def
+/Courier-Oblique starnetISO def
+/Courier-Bold starnetISO def
+/Courier-BoldOblique starnetISO def
+cleartomark
+} bind def
+
+%%BeginResource: procset graphviz 0 0
+/coord-font-family /Times-Roman def
+/default-font-family /Times-Roman def
+/coordfont coord-font-family findfont 8 scalefont def
+
+/InvScaleFactor 1.0 def
+/set_scale {
+       dup 1 exch div /InvScaleFactor exch def
+       scale
+} bind def
+
+% styles
+/solid { [] 0 setdash } bind def
+/dashed { [9 InvScaleFactor mul dup ] 0 setdash } bind def
+/dotted { [1 InvScaleFactor mul 6 InvScaleFactor mul] 0 setdash } bind def
+/invis {/fill {newpath} def /stroke {newpath} def /show {pop newpath} def} bind def
+/bold { 2 setlinewidth } bind def
+/filled { } bind def
+/unfilled { } bind def
+/rounded { } bind def
+/diagonals { } bind def
+/tapered { } bind def
+
+% hooks for setting color 
+/nodecolor { sethsbcolor } bind def
+/edgecolor { sethsbcolor } bind def
+/graphcolor { sethsbcolor } bind def
+/nopcolor {pop pop pop} bind def
+
+/beginpage {	% i j npages
+	/npages exch def
+	/j exch def
+	/i exch def
+	/str 10 string def
+	npages 1 gt {
+		gsave
+			coordfont setfont
+			0 0 moveto
+			(\() show i str cvs show (,) show j str cvs show (\)) show
+		grestore
+	} if
+} bind def
+
+/set_font {
+	findfont exch
+	scalefont setfont
+} def
+
+% draw text fitted to its expected width
+/alignedtext {			% width text
+	/text exch def
+	/width exch def
+	gsave
+		width 0 gt {
+			[] 0 setdash
+			text stringwidth pop width exch sub text length div 0 text ashow
+		} if
+	grestore
+} def
+
+/boxprim {				% xcorner ycorner xsize ysize
+		4 2 roll
+		moveto
+		2 copy
+		exch 0 rlineto
+		0 exch rlineto
+		pop neg 0 rlineto
+		closepath
+} bind def
+
+/ellipse_path {
+	/ry exch def
+	/rx exch def
+	/y exch def
+	/x exch def
+	matrix currentmatrix
+	newpath
+	x y translate
+	rx ry scale
+	0 0 1 0 360 arc
+	setmatrix
+} bind def
+
+/endpage { showpage } bind def
+/showpage { } def
+
+/layercolorseq
+	[	% layer color sequence - darkest to lightest
+		[0 0 0]
+		[.2 .8 .8]
+		[.4 .8 .8]
+		[.6 .8 .8]
+		[.8 .8 .8]
+	]
+def
+
+/layerlen layercolorseq length def
+
+/setlayer {/maxlayer exch def /curlayer exch def
+	layercolorseq curlayer 1 sub layerlen mod get
+	aload pop sethsbcolor
+	/nodecolor {nopcolor} def
+	/edgecolor {nopcolor} def
+	/graphcolor {nopcolor} def
+} bind def
+
+/onlayer { curlayer ne {invis} if } def
+
+/onlayers {
+	/myupper exch def
+	/mylower exch def
+	curlayer mylower lt
+	curlayer myupper gt
+	or
+	{invis} if
+} def
+
+/curlayer 0 def
+
+%%EndResource
+%%EndProlog
+%%BeginSetup
+14 default-font-family set_font
+% /arrowlength 10 def
+% /arrowwidth 5 def
+
+% make sure pdfmark is harmless for PS-interpreters other than Distiller
+/pdfmark where {pop} {userdict /pdfmark /cleartomark load put} ifelse
+% make '<<' and '>>' safe on PS Level 1 devices
+/languagelevel where {pop languagelevel}{1} ifelse
+2 lt {
+    userdict (<<) cvn ([) cvn load put
+    userdict (>>) cvn ([) cvn load put
+} if
+
+%%EndSetup
+setupLatin1
+%%Page: 1 1
+%%PageBoundingBox: 36 36 304 161
+%%PageOrientation: Portrait
+0 0 1 beginpage
+gsave
+36 36 268 125 boxprim clip newpath
+1 1 set_scale 0 rotate 40 40 translate
+% a
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 95.2 moveto 6.6708 (a) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 82 moveto
+12.3333 82 43.6667 82 43.6667 82 curveto
+49.3333 82 55 87.6667 55 93.3333 curveto
+55 93.3333 55 104.6667 55 104.6667 curveto
+55 110.3333 49.3333 116 43.6667 116 curveto
+43.6667 116 12.3333 116 12.3333 116 curveto
+6.6667 116 1 110.3333 1 104.6667 curveto
+1 104.6667 1 93.3333 1 93.3333 curveto
+1 87.6667 6.6667 82 12.3333 82 curveto
+stroke
+grestore
+% i_note_tr_a_b_1
+% a->i_note_tr_a_b_1
+gsave
+1 setlinewidth
+0 1 1 edgecolor
+newpath 28 80.68 moveto
+28 72.7409 28 65.0275 28 64.0943 curveto
+stroke
+grestore
+% b
+gsave
+0 0 0 nodecolor
+12 /Helvetica set_font
+24.6646 14.2 moveto 6.6708 (b) alignedtext
+2 setlinewidth
+solid
+0 0 0 nodecolor
+newpath 12.3333 1 moveto
+12.3333 1 43.6667 1 43.6667 1 curveto
+49.3333 1 55 6.6667 55 12.3333 curveto
+55 12.3333 55 23.6667 55 23.6667 curveto
+55 29.3333 49.3333 35 43.6667 35 curveto
+43.6667 35 12.3333 35 12.3333 35 curveto
+6.6667 35 1 29.3333 1 23.6667 curveto
+1 23.6667 1 12.3333 1 12.3333 curveto
+1 6.6667 6.6667 1 12.3333 1 curveto
+stroke
+grestore
+% i_note_tr_a_b_1->b
+gsave
+1 setlinewidth
+0 1 1 edgecolor
+newpath 28 63.868 moveto
+28 62.773 28 55.0116 28 46.1753 curveto
+stroke
+0 1 1 edgecolor
+newpath 31.5001 46.0401 moveto
+28 36.0401 lineto
+24.5001 46.0402 lineto
+closepath fill
+1 setlinewidth
+solid
+0 1 1 edgecolor
+newpath 31.5001 46.0401 moveto
+28 36.0401 lineto
+24.5001 46.0402 lineto
+closepath stroke
+0 1 1 edgecolor
+10 /Helvetica set_font
+28 47 moveto 2.779 ( ) alignedtext
+grestore
+% note_tr_a_b_1
+gsave
+0.16667 0.2 1 nodecolor
+newpath 254.1781 36 moveto
+77.8219 36 lineto
+77.8219 0 lineto
+260.1781 0 lineto
+260.1781 30 lineto
+closepath fill
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 254.1781 36 moveto
+77.8219 36 lineto
+77.8219 0 lineto
+260.1781 0 lineto
+260.1781 30 lineto
+closepath stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 254.1781 36 moveto
+254.1781 30 lineto
+stroke
+1 setlinewidth
+filled
+0 0 0 nodecolor
+newpath 260.1781 30 moveto
+254.1781 30 lineto
+stroke
+0 0 0 nodecolor
+10 /Helvetica set_font
+85.911 15 moveto 166.178 (edge stays red when attaching a note) alignedtext
+grestore
+% i_note_tr_a_b_1->note_tr_a_b_1
+gsave
+1 setlinewidth
+dashed
+0 0 0 edgecolor
+newpath 28.1022 63.9667 moveto
+30.5122 63.1804 75.0926 48.6365 113.4691 36.1164 curveto
+stroke
+grestore
+endpage
+showpage
+grestore
+%%PageTrailer
+%%EndPage: 1
+%%Trailer
+end
+restore
+%%EOF

--- a/test/render/vector/dot-to-vector-native.spec.js
+++ b/test/render/vector/dot-to-vector-native.spec.js
@@ -23,35 +23,38 @@ if (dotToVector.isAvailable()) {
 
   describe("dot-to-vector-native - convert", () => {
     it("renders an svg when presented with valid dot when no extra options passed", () => {
-      expect(dotToVector.convert("digraph { a }")).to.contain("<svg");
-      expect(dotToVector.convert("digraph { a }")).to.contain("</svg>");
+      const lFound = dotToVector.convert("digraph { a }");
+
+      expect(lFound).to.contain("<svg");
+      expect(lFound).to.contain("</svg>");
     });
 
     it("renders an svg when presented with valid dot when svg is passed as an explicit option", () => {
-      expect(
-        dotToVector.convert("digraph { a }", { format: "svg" })
-      ).to.contain("<svg");
-      expect(
-        dotToVector.convert("digraph { a }", { format: "svg" })
-      ).to.contain("</svg>");
+      const lFound = dotToVector.convert("digraph { a }", { format: "svg" });
+
+      expect(lFound).to.contain("<svg");
+      expect(lFound).to.contain("</svg>");
     });
 
     it("renders postscript when presented with valid dot when ps is passed as an option", () => {
-      expect(dotToVector.convert("digraph { a }", { format: "ps" })).to.contain(
-        "%!PS-Adobe-3.0"
-      );
-      expect(dotToVector.convert("digraph { a }", { format: "ps" })).to.contain(
-        "%%EOF"
-      );
+      const lFound = dotToVector.convert("digraph { a }", { format: "ps" });
+
+      expect(lFound).to.contain("%!PS-Adobe-3.0");
+      expect(lFound).to.contain("%%EOF");
     });
 
-    it("renders postscript when presented with valid dot when pss2 is passed as an option", () => {
-      expect(
-        dotToVector.convert("digraph { a }", { format: "ps2" })
-      ).to.contain("%!PS-Adobe-3.0");
-      expect(
-        dotToVector.convert("digraph { a }", { format: "ps2" })
-      ).to.contain("%%EOF");
+    it("renders postscript when presented with valid dot when ps2 is passed as an option", () => {
+      const lFound = dotToVector.convert("digraph { a }", { format: "ps2" });
+
+      expect(lFound).to.contain("%!PS-Adobe-3.0");
+      expect(lFound).to.contain("%%EOF");
+    });
+
+    it("renders encapsulated postscript when presented with valid dot when eps is passed as an option", () => {
+      const lFound = dotToVector.convert("digraph { a }", { format: "eps" });
+
+      expect(lFound).to.contain("%!PS-Adobe-3.0 EPSF-3.0");
+      expect(lFound).to.contain("%%EOF");
     });
 
     it("throws an error when presented with an invalid dot", () => {

--- a/test/render/vector/vector-with-viz-js.spec.js
+++ b/test/render/vector/vector-with-viz-js.spec.js
@@ -42,3 +42,20 @@ describe("#ast2ps2-with-viz-js - integration - ", () => {
     });
   });
 });
+
+describe("#ast2eps-with-viz-js - integration - ", () => {
+  FIXTURE_INPUTS.forEach((pInputFixture) => {
+    it(`correctly converts ${path.basename(
+      pInputFixture
+    )} to encapsulated postscript`, () => {
+      const lResult = convert(
+        JSON.parse(fs.readFileSync(pInputFixture, "utf8")),
+        { outputType: "oldeps" }
+      );
+
+      expect(lResult).to.deep.equal(
+        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".eps"), "utf8")
+      );
+    });
+  });
+});

--- a/tools/regenerate_render_fixtures.sh
+++ b/tools/regenerate_render_fixtures.sh
@@ -12,6 +12,7 @@ find -X test/parse/fixtures/no-color-*.smcat -exec bin/smcat -T json  {} ";" & \
 find -X test/parse/fixtures/no-color-*.smcat -exec bin/smcat -T dot --dot-node-attrs "color=pink"  {} ";" & \
 find -X test/render/fixtures/*.smcat -exec bin/smcat -T oldsvg  {} ";"
 find -X test/render/fixtures/*.smcat -exec bin/smcat -T oldps2  {} ";"
+find -X test/render/fixtures/*.smcat -exec bin/smcat -T oldeps  {} ";"
 mkdir -p test/render/fixtures/scxml
 find -X test/render/fixtures/*.scxml -exec bin/smcat -I scxml -T json {} -o {}.re-json ";"
 bin/smcat -T json test/parse/fixtures/composite.smcat


### PR DESCRIPTION
## Description, Motivation and Context

See title; another attempt to produce something LaTeX build pipelines can ingest (see #129)

This PR is also published on npm as a beta: `state-machine-cat@7.3.0-beta-1`

## How Has This Been Tested?

- [x] automated non-regression tests + green ci
- [x] additional unit tests for .eps

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
