### PR TITLE
bugfix(types|json-schema): type the width attribute on transitions

### DIFF
--- a/src/parse/smcat-ast.schema.json
+++ b/src/parse/smcat-ast.schema.json
@@ -149,7 +149,9 @@
               },
               "width": {
                 "description": "The line width to use for rendering the transition",
-                "type": "number"
+                "type": "number",
+                "minimum": 0,
+                "maximum": 30
               },
               "class": {
                 "description": "Class name to give the state in dot and svg output.",

--- a/types/state-machine-cat.d.ts
+++ b/types/state-machine-cat.d.ts
@@ -119,6 +119,10 @@ export interface ITransition {
    */
   color?: string;
   /**
+   * The line width to use for rendering the transition
+   */
+  width?: number;
+  /**
    * Class name to give the transition in dot and svg output.
    */
   class?: string;


### PR DESCRIPTION
## Description

- adds the `width` attribute on the type of transitions
- adds sensible restrictions on the width in the json schema

## Motivation and Context

- type refs need to be in sync with reality

## How Has This Been Tested?

- [x] automated non-regression tests & green ci


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
