### PR TITLE
feature(cli): updates the vizjs warning & the condition under which it shows

### DIFF
--- a/bin/smcat.mjs
+++ b/bin/smcat.mjs
@@ -35,7 +35,7 @@ function presentError(pError) {
 try {
   program
     .version($package.version)
-    .description(makeDescription(process.versions.node))
+    .description(makeDescription())
     .option(
       "-T --output-type <type>",
       validations.validOutputTypeRE,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
-### <a id="node12"></a>Q: I'm on node 12 and get a warning when I convert to svg with the cli. What's up?
+### <a id="viz"></a>Q: I get a warning when I convert to svg with the cli. What's up?
 
-**A**: On Node.js 12 (and up) you might see a warning message on stderr:
+**A**: You might see a warning message on stderr:
 _Invalid asm.js: Function definition doesn't match use_.
 
 This happens when state-machine-cat can't find a graphviz dot executable. In
@@ -8,7 +8,7 @@ these cases it falls back to [viz.js](https://github.com/mdaines/viz.js),
 a graphviz version compiled to javascript. One of viz.js'
 [known issues](https://github.com/mdaines/viz.js/issues/96) is that it triggers
 this scary looking error message in the node runtime. It's harmless and the
-svg will come out just fine
+svg will come out just fine.
 
 If you want to get rid of the message install GraphViz dot and ensure it's
 available in your environments' `path`. GrapViz is readily available on all

--- a/src/cli/make-description.mjs
+++ b/src/cli/make-description.mjs
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import indentString from "indent-string";
 import wrapAnsi from "wrap-ansi";
-import satisfies from "semver/functions/satisfies.js";
+import dotToVectorNative from "../render/vector/dot-to-vector-native.mjs";
 
 function wrapAndIndent(pString) {
   const lDogmaticMaxConsoleWidth = 78;
@@ -12,20 +12,21 @@ function wrapAndIndent(pString) {
   return indentString(wrapAnsi(pString, MAX_WIDTH), lDefaultIndent);
 }
 
-export default (pNodeVersion) => {
+export default (pDotIsAvailable = dotToVectorNative.isAvailable({})) => {
   const lDescription =
     "Write beautiful state charts - https://github.com/sverweij/state-machine-cat";
   const lNode12Warning =
-    "When you output svg on node >=12, you might see " +
+    "When you want to output svg and the native GraphViz isn't installed, " +
+    "state-machine-cat will fall back to viz.js and you might see " +
     `${chalk.italic(
       "'Invalid asm.js: Function definition doesn't match use'"
     )}. ` +
-    "It's harmless. See " +
-    `https://github.com/sverweij/state-machine-cat/blob/develop/docs/faq.md#q-im-on-node-12-and-get-a-warning-when-i-convert-to-svg-with-the-cli-whats-up`;
+    "It's harmless and your svg will come out ok. See " +
+    `https://github.com/sverweij/state-machine-cat/blob/develop/docs/faq.md#viz`;
 
   return indentString(
-    satisfies(pNodeVersion, ">=12")
-      ? `${lDescription}\n\n${wrapAndIndent(chalk.dim(lNode12Warning))}`
-      : lDescription
+    pDotIsAvailable
+      ? lDescription
+      : `${lDescription}\n\n${wrapAndIndent(chalk.dim(lNode12Warning))}`
   );
 };

--- a/test/cli/make-description.spec.mjs
+++ b/test/cli/make-description.spec.mjs
@@ -2,12 +2,16 @@ import { expect } from "chai";
 import makeDescription from "../../src/cli/make-description.mjs";
 
 describe("#cli - makeDescription", () => {
-  it("tells about the asm.js warning on node >=12", () => {
-    expect(makeDescription("v12.11.1")).to.contain(">=12");
+  it("tells about the asm.js when graphviz dot can't be found", () => {
+    expect(makeDescription(false)).to.contain(
+      "When you want to output svg and the native GraphViz isn't installed"
+    );
   });
 
-  it("doesn't tell about the asm.js warning on node <12", () => {
-    expect(makeDescription("v10.16.3")).to.not.contain(">=12");
+  it("doesn't tell about the asm.js when an AOK version of dot can be executed", () => {
+    expect(makeDescription(true)).to.not.contain(
+      "When you want to output svg and the native GraphViz isn't installed"
+    );
   });
 });
 /* eslint no-undefined: 0 */


### PR DESCRIPTION
## Description

- updates the vizjs warning `--help` shows to be more actionable
- updates the condition under which the warning shows:
  - _before_: always show under node >= 12
  - _after_: always show when the GraphViz' `dot` command isn't available
- updates the FAQ to match the message in --help

## Motivation and Context

The `Invalid asm.js` message does indeed occur under node >=12, but only when GraphViz dot isn't installed. Also node >= 12 is not a distinguishing factor anymore as the only nodejs versions state-machine-cat supports are >= 12 anyway.

## How Has This Been Tested?

- [x] automated non-regression tests
- [ ] green ci
- [ ] updated unit tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
