### PR TITLE
feature: adds png and pdf output formats (native graphviz only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Usage: smcat [options] [infile]
 
 Options:
   -V, --version               output the version number
-  -T --output-type <type>     svg|eps|ps|ps2|dot|smcat|json|ast|scxml|oldsvg|scjson (default: "svg")
+  -T --output-type <type>     svg|eps|ps|ps2|dot|smcat|json|ast|scxml|oldsvg|scjson|pdf|png (default: "svg")
   -I --input-type <type>      smcat|json|scxml (default: "smcat")
   -E --engine <type>          dot|circo|fdp|neato|osage|twopi (default: "dot")
   -d --direction <dir>        top-down|bottom-top|left-right|right-left (default: "top-down")

--- a/bin/smcat.mjs
+++ b/bin/smcat.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
 import { program } from "commander";
 import satisfies from "semver/functions/satisfies.js";
-import { readFileSync } from "node:fs";
 import actions from "../src/cli/actions.mjs";
 import makeDescription from "../src/cli/make-description.mjs";
 import normalize from "../src/cli/normalize.mjs";
@@ -86,9 +86,11 @@ try {
     })
     .arguments("[infile]")
     .parse(process.argv);
-  actions.transform(
-    validations.validateArguments(normalize(program.args[0], program.opts()))
-  );
+  actions
+    .transform(
+      validations.validateArguments(normalize(program.args[0], program.opts()))
+    )
+    .catch(presentError);
 } catch (pError) {
   presentError(pError);
 }

--- a/package.json
+++ b/package.json
@@ -427,6 +427,8 @@
     "eslint-plugin-security": "1.5.0",
     "eslint-plugin-unicorn": "43.0.2",
     "husky": "8.0.1",
+    "is-pdf": "1.0.0",
+    "is-png": "3.0.1",
     "lint-staged": "13.0.3",
     "mocha": "10.0.0",
     "npm-run-all": "4.1.5",

--- a/src/cli/actions.mjs
+++ b/src/cli/actions.mjs
@@ -49,7 +49,7 @@ export default {
         typeof lOutput === "string"
           ? lOutput
           : JSON.stringify(lOutput, null, "    "),
-        "utf8"
+        "binary"
       );
     });
   },

--- a/src/cli/file-name-to-stream.mjs
+++ b/src/cli/file-name-to-stream.mjs
@@ -2,12 +2,22 @@
 
 import * as fs from "node:fs";
 
+/**
+ *
+ * @param {string} pOutputTo
+ * @returns {import("node:fs").WriteStream}
+ */
 export function getOutStream(pOutputTo) {
   if ("-" === pOutputTo) {
     return process.stdout;
   }
   return fs.createWriteStream(pOutputTo);
 }
+/**
+ *
+ * @param {string} pInputFrom
+ * @returns {import("node:fs").ReadStream}
+ */
 export function getInStream(pInputFrom) {
   if ("-" === pInputFrom) {
     return process.stdin;

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -19,6 +19,8 @@ const ALLOWED_VALUES = Object.freeze({
       { name: "oldps2" },
       { name: "oldeps" },
       { name: "scjson" },
+      { name: "pdf" },
+      { name: "png" },
     ],
   },
   engine: {

--- a/src/render/index-node.mjs
+++ b/src/render/index-node.mjs
@@ -18,6 +18,8 @@ export default function getRenderFunction(pOutputType) {
     oldsvg: oldVector,
     oldps2: oldVector,
     oldeps: oldVector,
+    pdf: vector,
+    png: vector,
     scjson,
     scxml,
   };

--- a/src/render/vector/dot-to-vector-native.mjs
+++ b/src/render/vector/dot-to-vector-native.mjs
@@ -34,7 +34,7 @@ function convert(pDot, pOptions) {
   //  1: error in the program
   // -2: executable not found
   if (status === 0) {
-    return stdout.toString("utf8");
+    return stdout.toString("binary");
   } else if (error) {
     throw new Error(error);
   } else {

--- a/src/render/vector/vector-native-dot-with-fallback.mjs
+++ b/src/render/vector/vector-native-dot-with-fallback.mjs
@@ -1,10 +1,6 @@
 import dotToSvgJs from "viz.js";
 import indentString from "indent-string";
 import wrapAnsi from "wrap-ansi";
-// seems eslint-plugin-import and eslint-plugin-node can't handle exports
-// fields yet. No man overboard not checking against this, because dependency-cruiser
-// will also find them
-
 import chalk from "chalk";
 import options from "../../options.mjs";
 import ast2dot from "../dot/index.mjs";
@@ -12,6 +8,8 @@ import dotToVectorNative from "./dot-to-vector-native.mjs";
 
 const DEFAULT_INDENT = 2;
 const DOGMATIC_CONSOLE_WIDTH = 78;
+const VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS = ["pdf", "png"];
+
 export default (pAST, pOptions) => {
   const lDotProgram = ast2dot(pAST, pOptions);
   const lDotOptions = {
@@ -27,7 +25,7 @@ export default (pAST, pOptions) => {
         wrapAnsi(
           `\n${chalk.yellow(
             "warning:"
-          )} GraphViz 'dot' executable not found. Falling back to svg.js.\n\n` +
+          )} GraphViz 'dot' executable not found. Falling back to viz.js.\n\n` +
             "On node >=12 this fallback will trigger a warning from the " +
             `node runtime:\n${chalk.italic(
               "Invalid asm.js: Function definition doesn't match use"
@@ -41,6 +39,14 @@ export default (pAST, pOptions) => {
         DEFAULT_INDENT
       )
     );
+
+    if (VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS.includes(lDotOptions.format)) {
+      throw new Error(
+        "'viz.js' doesn't support the 'pdf' and 'png' output formats. Either " +
+          "select a format that it does support or install GraphViz " +
+          "(recommended), which has support for both formats.\n"
+      );
+    }
     return dotToSvgJs(lDotProgram, lDotOptions);
   }
 };

--- a/src/render/vector/vector-native-dot-with-fallback.mjs
+++ b/src/render/vector/vector-native-dot-with-fallback.mjs
@@ -20,6 +20,15 @@ export default (pAST, pOptions) => {
   if (dotToVectorNative.isAvailable(pOptions)) {
     return dotToVectorNative.convert(lDotProgram, lDotOptions);
   } else {
+    if (VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS.includes(lDotOptions.format)) {
+      throw new Error(
+        "GraphViz 'dot' executable not found. Falling back to viz.js.\n\n" +
+          "'viz.js' doesn't support the 'pdf' and 'png' output formats. Either " +
+          "select a format that it does support or install GraphViz " +
+          "(recommended), which has support for both formats.\n"
+      );
+    }
+
     process.stderr.write(
       indentString(
         wrapAnsi(
@@ -40,13 +49,6 @@ export default (pAST, pOptions) => {
       )
     );
 
-    if (VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS.includes(lDotOptions.format)) {
-      throw new Error(
-        "'viz.js' doesn't support the 'pdf' and 'png' output formats. Either " +
-          "select a format that it does support or install GraphViz " +
-          "(recommended), which has support for both formats.\n"
-      );
-    }
     return dotToSvgJs(lDotProgram, lDotOptions);
   }
 };

--- a/test/render/vector/dot-to-vector-native.spec.mjs
+++ b/test/render/vector/dot-to-vector-native.spec.mjs
@@ -1,4 +1,6 @@
 import { expect } from "chai";
+import isPng from "is-png";
+import isPdf from "is-pdf";
 import dotToVector from "../../../src/render/vector/dot-to-vector-native.mjs";
 
 if (dotToVector.isAvailable()) {
@@ -53,6 +55,24 @@ if (dotToVector.isAvailable()) {
 
       expect(lFound).to.contain("%!PS-Adobe-3.0 EPSF-3.0");
       expect(lFound).to.contain("%%EOF");
+    });
+
+    it("renders png when presented with valid dot when png is passed as an option", () => {
+      const lFound = dotToVector.convert("digraph { a }", {
+        format: "png",
+      });
+      const lFoundAsBuffer = Buffer.from(lFound, "binary");
+
+      expect(isPng(lFoundAsBuffer)).to.equal(true);
+    });
+
+    it("renders pdf when presented with valid dot when pdf is passed as an option", () => {
+      const lFound = dotToVector.convert("digraph { a }", {
+        format: "pdf",
+      });
+      const lFoundAsBuffer = Buffer.from(lFound, "binary");
+
+      expect(isPdf(lFoundAsBuffer)).to.equal(true);
     });
 
     it("throws an error when presented with an invalid dot", () => {

--- a/test/render/vector/vector-native-dot-with-fallback.spec.mjs
+++ b/test/render/vector/vector-native-dot-with-fallback.spec.mjs
@@ -28,12 +28,21 @@ describe("svg-native-dot-with-fallback", () => {
     expect(lOutput).to.contain("</svg>");
   });
 
-  it("returns an SVG when the 'dot' program doesn't exists and is in the path", () => {
+  it("returns an SVG when the 'dot' program doesn't exist", () => {
     const lOutput = dotToSVG(AST, {
       exec: "this_executable_does_not_exist_for_sure",
     });
 
     expect(lOutput).to.contain("<svg");
     expect(lOutput).to.contain("</svg>");
+  });
+
+  it("throws when the 'dot' program doesn't exists and an viz.js unsupported format is requested", () => {
+    expect(() => {
+      dotToSVG(AST, {
+        exec: "this_executable_does_not_exist_for_sure",
+        outputType: "png",
+      });
+    }).to.throw();
   });
 });


### PR DESCRIPTION
## Description

- adds png and pdf output to the command line version
- only works with the _native_ graphviz dot (not with viz.js,  which we use as a fallback and that doesn't support these formats).

needs
- [x] error handling for when we have to fall back to viz.js (that doesn't support png or pdf output)

## Motivation and Context

fixes #165 

## How Has This Been Tested?

- [x] green ci
- [x] manual tests
- [x] additional unit tests (that checks whether the returned png & pdf are valid)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
