### PR TITLE
doc: type the codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     {
       "files": ["**/*.js", "**/*.mjs"],
       "rules": {
-        "unicorn/prefer-spread": "off"
+        "unicorn/prefer-spread": "off",
+        "unicorn/prefer-top-level-await": "off"
       }
     },
     {
@@ -40,7 +41,7 @@
       }
     },
     {
-      "files": ["types/*.ts"],
+      "files": ["*.d.ts", "*.d.mts"],
       "plugins": ["@typescript-eslint"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "parser": "@typescript-eslint/parser",
@@ -48,7 +49,10 @@
         "ecmaVersion": 2021
       },
       "rules": {
-        "node/no-unsupported-features/es-syntax": "off"
+        "node/no-unsupported-features/es-syntax": "off",
+        "no-inline-comments": "off",
+        "import/no-unresolved": "off",
+        "node/no-missing-import": "off"
       }
     }
   ]

--- a/bin/smcat.mjs
+++ b/bin/smcat.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 import { readFileSync } from "node:fs";
 import { program } from "commander";
 import satisfies from "semver/functions/satisfies.js";
@@ -25,6 +26,10 @@ if (!satisfies(process.versions.node, $package.engines.node)) {
 }
 /* c8 ignore stop */
 
+/**
+ * @param {any} pError
+ * @return {void}
+ */
 function presentError(pError) {
   process.stderr.write(actions.formatError(pError));
 

--- a/config/dependency-cruiser.js
+++ b/config/dependency-cruiser.js
@@ -1,7 +1,37 @@
+// @ts-check
+/* eslint-disable max-lines */
+const DOT_FILE_PATTERN = "(^|/)\\.[^/]+\\.(js|cjs|mjs|ts|json)$";
+const TS_DECLARATION_FILE_PATTERN = "\\.d\\.(c|m)?ts$";
+const TS_CONFIG_FILE_PATTERN = "(^|/)tsconfig\\.json$";
+const OTHER_CONFIG_FILES_PATTERN =
+  "(^|/)(babel|webpack)\\.config\\.(js|cjs|mjs|ts|json)$";
+
+const KNOWN_CONFIG_FILE_PATTERNS = [
+  DOT_FILE_PATTERN,
+  TS_DECLARATION_FILE_PATTERN,
+  TS_CONFIG_FILE_PATTERN,
+  OTHER_CONFIG_FILES_PATTERN,
+].join("|");
+
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {
   extends: "dependency-cruiser/configs/recommended-strict",
   forbidden: [
+    {
+      name: "no-orphans",
+      comment:
+        "This is an orphan module - it's likely not used (anymore?). Either use it or " +
+        "remove it. If it's logical this module is an orphan (i.e. it's a config file), " +
+        "add an exception for it in your dependency-cruiser configuration. By default " +
+        "this rule does not scrutinize dotfiles (e.g. .eslintrc.js), TypeScript declaration " +
+        "files (.d.ts), tsconfig.json and some of the babel and webpack configs.",
+      severity: "warn",
+      from: {
+        orphan: true,
+        pathNot: KNOWN_CONFIG_FILE_PATTERNS,
+      },
+      to: {},
+    },
     {
       name: "optional-deps-used",
       severity: "error",
@@ -184,6 +214,7 @@ module.exports = {
           "^src/cli/|^src/render/scjson/scjson.schema\\.json$",
           "^src/index\\.mjs",
           "^src/index-node\\.mjs",
+          "\\.d\\.(c|m)?ts$",
         ],
         reachable: false,
       },
@@ -201,6 +232,7 @@ module.exports = {
       to: {
         path: "^src/",
         reachable: false,
+        pathNot: ["\\.d\\.(c|m)?ts$"],
       },
     },
     {
@@ -240,7 +272,11 @@ module.exports = {
           modules: [
             {
               criteria: { matchesHighlight: true },
-              attributes: { fillcolor: "yellow" },
+              attributes: {
+                fillcolor: "yellow",
+                color: "green",
+                penwidth: 2,
+              },
             },
             {
               criteria: { source: "^src/cli" },
@@ -256,7 +292,7 @@ module.exports = {
             },
             {
               criteria: {
-                source: "(-parser|\\.template|\\.schema|version)\\.c?js$",
+                source: "(-parser|\\.template|\\.schema|version)\\.m?js$",
               },
               attributes: { style: "filled", color: "gray" },
             },

--- a/package.json
+++ b/package.json
@@ -244,13 +244,13 @@
       ]
     },
     "depcruise:graph:dev": {
-      "command": "depcruise-fmt node_modules/.cache/depcruise-cache.json --output-type dot --include-only '^(bin|src|package\\.json)' --prefix vscode://file/$(pwd)/ --highlight \"$(watskeburt)\"| dot -Tsvg | depcruise-wrap-stream-in-html | browser",
+      "command": "depcruise-fmt node_modules/.cache/depcruise-cache.json --output-type dot --include-only '^(bin|src|package\\.json)' --prefix vscode://file/$(pwd)/ --highlight \"$(watskeburt develop)\"| dot -Tsvg | depcruise-wrap-stream-in-html | browser",
       "dependencies": [
         "depcruise:json"
       ]
     },
     "depcruise:graph:dev:flat": {
-      "command": "depcruise-fmt node_modules/.cache/depcruise-cache.json --output-type flat --include-only '^(bin|src|package\\.json)' --prefix vscode://file/$(pwd)/ | twopi -Tsvg | depcruise-wrap-stream-in-html | browser",
+      "command": "depcruise-fmt node_modules/.cache/depcruise-cache.json --output-type flat --include-only '^(bin|src|package\\.json)' --prefix vscode://file/$(pwd)/ --highlight \"$(watskeburt develop)\"| twopi -Tsvg | depcruise-wrap-stream-in-html | browser",
       "dependencies": [
         "depcruise:json"
       ]
@@ -301,7 +301,7 @@
       ]
     },
     "lint:prettier": {
-      "command": "prettier --check \"bin/*.mjs\" \"{src,test}/**/*.{js,mjs}\" \"{config,test}/**/*.{js,json}\" \"tools/*.{js,mjs,json}\" \"types/*.ts\" \"*.{json,yml,md}\" \"docs/{smcat-online-interpreter.js,*.md}\"",
+      "command": "prettier --check \"bin/*.mjs\" \"{src,test}/**/*.{js,mjs}\" \"{config,test}/**/*.{js,json}\" \"tools/*.{js,mjs,json}\" \"{src,types}/**/*.{ts,mts}\" \"*.{json,yml,md}\" \"docs/{smcat-online-interpreter.js,*.md}\"",
       "files": [
         "bin/*.mjs",
         "{src,test}/**/*.{js,mjs}",
@@ -319,15 +319,15 @@
       ]
     },
     "lint:types:tsc": {
-      "command": "tsc --noEmit --strict --types --noUnusedLocals --noUnusedParameters --pretty types/*.d.ts",
+      "command": "tsc --noEmit --strict --types --noUnusedLocals --noUnusedParameters --pretty types/*.d.ts src/cli/*.d.mts src/cli/*.d.ts src/parse/scxml/*.d.ts",
       "files": [
         "types/*.d.ts"
       ]
     },
     "lint:types:eslint": {
-      "command": "eslint types/*.d.ts",
+      "command": "eslint types/*.d.ts src/cli/*.d.mts src/cli/*.d.ts src/parse/scxml/*.d.ts",
       "files": [
-        "types/*.d.ts",
+        "{src,types}/**/*.d.{ts,mts}",
         ".eslintrc.json"
       ]
     },
@@ -347,10 +347,10 @@
       ]
     },
     "lint:fix:prettier": {
-      "command": "prettier --loglevel warn --write \"bin/*.mjs\" \"{src,test}/**/*.{js,mjs}\" \"{config,test}/**/*.{js,json}\" \"tools/*.{js,mjs,json}\" \"types/*.ts\" \"*.{json,yml,md}\" \"docs/{smcat-online-interpreter.js,*.md}\"",
+      "command": "prettier --loglevel warn --write \"bin/*.mjs\" \"{src,test}/**/*.{js,mjs}\" \"{config,test}/**/*.{js,json}\" \"tools/*.{js,mjs,json}\" \"{src,types}/**/*.{ts,mts}\" \"*.{json,yml,md}\" \"docs/{smcat-online-interpreter.js,*.md}\"",
       "files": [
         "bin/*.mjs",
-        "{src,test}/**/*.{js,mjs}",
+        "{src,test}/**/*.{js,mjs,ts,mts}",
         "{config,test}/**/*.{js,json}",
         "tools/*.{js,mjs,json}",
         "types/*.ts",
@@ -359,9 +359,9 @@
       ]
     },
     "lint:fix:types": {
-      "command": "eslint --fix types/*.d.ts",
+      "command": "eslint --fix types/*.d.ts src/cli/*.d.mts src/cli/*.d.ts src/parse/scxml/*.d.ts",
       "files": [
-        "types/*.d.ts",
+        "{src,types}/**/*.d.{ts,mts}",
         ".eslintrc.json"
       ]
     },
@@ -372,7 +372,7 @@
       ]
     },
     "test:cover": {
-      "command": "c8 --all --check-coverage --statements 100 --branches 99.1 --functions 100 --lines 100 --exclude \"{bin/*,config/**/*,coverage/**/*,docs/**/*,public/**/*,test/**/*,tools/**/*,types/**/*,dist/commonjs/*,src/**/*{template,-parser}.{mjs,cjs,js},tmp*}\" --reporter text-summary --reporter html --reporter lcov mocha",
+      "command": "c8 --all --check-coverage --statements 100 --branches 99.1 --functions 100 --lines 100 --exclude \"{bin/*,config/**/*,coverage/**/*,docs/**/*,public/**/*,test/**/*,tools/**/*,types/**/*,dist/commonjs/*,src/**/*.d.{ts,mts},src/**/*{template,-parser}.{mjs,cjs,js},tmp*}\" --reporter text-summary --reporter html --reporter lcov mocha",
       "output": [
         "coverage/lcov.info"
       ],

--- a/src/cli/actions.mjs
+++ b/src/cli/actions.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import getStream from "get-stream";
 import smcat from "../index-node.mjs";
 import { getOutStream, getInStream } from "./file-name-to-stream.mjs";
@@ -31,7 +32,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 `;
 
 export default {
+  /** @type {string} */
   LICENSE,
+  /**
+   * @param {import("./cli").ICLIRenderOptions} pOptions
+   */
   transform(pOptions) {
     return getStream(getInStream(pOptions.inputFrom)).then((pInput) => {
       const lOutput = smcat.render(pInput, {
@@ -54,6 +59,10 @@ export default {
     });
   },
 
+  /**
+   * @param {any} pError
+   * @returns {string}
+   */
   formatError(pError) {
     if (Boolean(pError.location)) {
       return `\n  syntax error on line ${pError.location.start.line}, column ${pError.location.start.column}:\n  ${pError.message}\n\n`;

--- a/src/cli/attributes-parser.d.mts
+++ b/src/cli/attributes-parser.d.mts
@@ -1,0 +1,3 @@
+import { dotAttributesType } from "../../types/state-machine-cat";
+
+export function parse(input: string, options?: unknown): dotAttributesType;

--- a/src/cli/cli.d.ts
+++ b/src/cli/cli.d.ts
@@ -1,0 +1,26 @@
+import {
+  IRenderOptions,
+  IBaseRenderOptions,
+} from "../../types/state-machine-cat";
+
+export interface ICLIRenderOptions extends IRenderOptions {
+  inputFrom: string;
+  outputTo: string;
+}
+
+export interface ILooseCLIRenderOptions extends Partial<IBaseRenderOptions> {
+  inputFrom?: string;
+  outputTo?: string;
+  /**
+   * For the 'dot' renderer: Graph attributes to the engine
+   */
+  dotGraphAttrs?: string;
+  /**
+   * For the 'dot' renderer: Node attributes to the engine
+   */
+  dotNodeAttrs?: string;
+  /**
+   * For the 'dot' renderer: Edge attributes to the engine
+   */
+  dotEdgeAttrs?: string;
+}

--- a/src/cli/file-name-to-stream.mjs
+++ b/src/cli/file-name-to-stream.mjs
@@ -1,11 +1,10 @@
+// @ts-check
 /* eslint-disable security/detect-non-literal-fs-filename */
-
-import * as fs from "node:fs";
+import fs from "node:fs";
 
 /**
- *
  * @param {string} pOutputTo
- * @returns {import("node:fs").WriteStream}
+ * @returns {NodeJS.WritableStream}
  */
 export function getOutStream(pOutputTo) {
   if ("-" === pOutputTo) {
@@ -13,10 +12,10 @@ export function getOutStream(pOutputTo) {
   }
   return fs.createWriteStream(pOutputTo);
 }
+
 /**
- *
  * @param {string} pInputFrom
- * @returns {import("node:fs").ReadStream}
+ * @returns {NodeJS.ReadableStream}
  */
 export function getInStream(pInputFrom) {
   if ("-" === pInputFrom) {

--- a/src/cli/make-description.mjs
+++ b/src/cli/make-description.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 // seems eslint-plugin-import and eslint-plugin-node can't handle exports
 // fields yet. No man overboard not checking against this, because dependency-cruiser
 // will also find them
@@ -7,6 +8,10 @@ import indentString from "indent-string";
 import wrapAnsi from "wrap-ansi";
 import dotToVectorNative from "../render/vector/dot-to-vector-native.mjs";
 
+/**
+ * @param {string} pString
+ * @returns {string}
+ */
 function wrapAndIndent(pString) {
   const lDogmaticMaxConsoleWidth = 78;
   const lDefaultIndent = 2;
@@ -16,6 +21,10 @@ function wrapAndIndent(pString) {
   return indentString(wrapAnsi(pString, lMaxWidth), lDefaultIndent);
 }
 
+/**
+ * @param {boolean} pDotIsAvailable
+ * @return {string}
+ */
 export default (pDotIsAvailable = dotToVectorNative.isAvailable({})) => {
   const lDescription =
     "Write beautiful state charts - https://github.com/sverweij/state-machine-cat";

--- a/src/cli/validations.mjs
+++ b/src/cli/validations.mjs
@@ -1,9 +1,14 @@
+// @ts-check
 import fs from "node:fs";
 import smcat from "../index-node.mjs";
 import { parse as parseAttributes } from "./attributes-parser.mjs";
 
 const allowedValues = smcat.getAllowedValues();
 
+/**
+ * @param {{name: string}} pValue
+ * @returns {string}
+ */
 function getName(pValue) {
   return pValue.name;
 }
@@ -13,14 +18,22 @@ const VALID_INPUT_TYPES = allowedValues.inputType.values.map(getName);
 const VALID_ENGINES = allowedValues.engine.values.map(getName);
 const VALID_DIRECTIONS = allowedValues.direction.values.map(getName);
 
+/**
+ * @param {string} pFilename
+ * @returns {boolean}
+ */
 function isStdout(pFilename) {
   return "-" === pFilename;
 }
 
+/**
+ * @param {string} pFilename
+ * @returns {boolean}
+ */
 function fileExists(pFilename) {
   try {
     if (!isStdout(pFilename)) {
-      fs.accessSync(pFilename, fs.R_OK);
+      fs.accessSync(pFilename, fs.constants.R_OK);
     }
     return true;
   } catch (pError) {
@@ -28,6 +41,15 @@ function fileExists(pFilename) {
   }
 }
 
+/**
+ * This function is shaped so it can serve as a validation function in a
+ * commander option.
+ *
+ * @param {keyof import("../../types/state-machine-cat").IRenderOptions} pOption
+ * @param {string[]} pValidValues
+ * @param {string} pError
+ * @returns {never|keyof import("../../types/state-machine-cat").IRenderOptions}
+ */
 function validOption(pOption, pValidValues, pError) {
   if (pValidValues.includes(pOption)) {
     return pOption;
@@ -78,6 +100,10 @@ export default {
     }
   },
 
+  /**
+   * @param {import("./cli").ICLIRenderOptions} pOptions
+   * @returns {never|import("./cli").ICLIRenderOptions}
+   */
   validateArguments(pOptions) {
     if (!pOptions.inputFrom) {
       throw new Error(`\n  error: Please specify an input file.\n\n`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable budapestian/global-constant-pattern */
 import options from "./options.mjs";
 import parse from "./parse/index.mjs";
@@ -8,12 +9,11 @@ import { version as _version } from "./version.mjs";
 /**
  * Translates the input script to an output-script.
  *
- * @param  {string} pScript     The script to translate
- * @param  {object} pOptions    options influencing parsing & rendering.
- *                              See below for the complete list.
- * @return {string|void}        nothing if a callback was passed, the
- *                              string with the rendered content if
- *                              no callback was passed and no error was found
+ * @param  {string|import("../types/state-machine-cat").IStateMachine} pScript
+ *                              The script to translate
+ * @param  {import("../types/state-machine-cat").IRenderOptions} pOptions
+ *                              options influencing parsing & rendering.
+ * @return {string}
  * @throws {Error}              if an error occurred and no callback
  *                              function was passed: the error
  *
@@ -21,11 +21,11 @@ import { version as _version } from "./version.mjs";
  *
  */
 export function render(pScript, pOptions) {
-  const lAST = parse.getAST(pScript, pOptions);
+  const lStateMachine = parse.getAST(pScript, pOptions);
   const lDesugar = options.getOptionValue(pOptions, "desugar");
 
   return getRenderFunction(options.getOptionValue(pOptions, "outputType"))(
-    lDesugar ? desugar(lAST) : lAST,
+    lDesugar ? desugar(lStateMachine) : lStateMachine,
     pOptions
   );
 }
@@ -45,7 +45,7 @@ export const version = _version;
  * - the possible values in an array of objects, each of which
  *   has the properties:
  *   - name: the value
- *
+ * @returns {import("../types/state-machine-cat").IAllowedValues}
  */
 export function getAllowedValues() {
   return options.getAllowedValues();

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+/** @type {import("../types/state-machine-cat").IAllowedValues} */
 const ALLOWED_VALUES = Object.freeze({
   inputType: {
     default: "smcat",
@@ -6,21 +8,22 @@ const ALLOWED_VALUES = Object.freeze({
   outputType: {
     default: "svg",
     values: [
-      { name: "svg" },
-      { name: "eps" },
-      { name: "ps" },
-      { name: "ps2" },
-      { name: "dot" },
-      { name: "smcat" },
-      { name: "json" },
       { name: "ast" },
-      { name: "scxml" },
-      { name: "oldsvg" },
-      { name: "oldps2" },
+      { name: "dot" },
+      { name: "eps" },
+      { name: "json" },
       { name: "oldeps" },
-      { name: "scjson" },
+      { name: "oldps" },
+      { name: "oldps2" },
+      { name: "oldsvg" },
       { name: "pdf" },
       { name: "png" },
+      { name: "ps" },
+      { name: "ps2" },
+      { name: "scjson" },
+      { name: "scxml" },
+      { name: "smcat" },
+      { name: "svg" },
     ],
   },
   engine: {
@@ -53,15 +56,18 @@ const ALLOWED_VALUES = Object.freeze({
  * Returns the value for the option in the pOption object, and the default
  * for that option in all other cases
  *
- * @param {any} pOptions - the options as passed in the api `render` function
- * @param {string} pOptionName - the name of the option
- * @return {any} value
+ * @param {import("../types/state-machine-cat").IRenderOptions} pOptions - the options as passed in the api `render` function
+ * @param {keyof import("../types/state-machine-cat").IRenderOptions} pOptionName - the name of the option
+ * @return {string|boolean} value
  */
 function getOptionValue(pOptions, pOptionName) {
   // eslint-disable-next-line security/detect-object-injection
   return pOptions?.[pOptionName] ?? ALLOWED_VALUES[pOptionName].default;
 }
 
+/**
+ * @returns {import("../types/state-machine-cat").IAllowedValues}
+ */
 function getAllowedValues() {
   return ALLOWED_VALUES;
 }

--- a/src/parse/index.mjs
+++ b/src/parse/index.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import Ajv from "ajv";
 import options from "../options.mjs";
 import { parse as parseSmCat } from "./smcat/smcat-parser.mjs";
@@ -6,6 +7,11 @@ import $schema from "./smcat-ast.schema.mjs";
 
 const ajv = new Ajv();
 
+/**
+ * @param {typeof $schema} pSchema
+ * @param {any} pObject
+ * @throws {Error}
+ */
 function validateAgainstSchema(pSchema, pObject) {
   if (!ajv.validate(pSchema, pObject)) {
     throw new Error(
@@ -15,12 +21,18 @@ function validateAgainstSchema(pSchema, pObject) {
 }
 
 export default {
+  /**
+   * @param {string|import("../../types/state-machine-cat").IStateMachine} pScript
+   * @param {import("../../types/state-machine-cat").IRenderOptions} pOptions
+   * @returns {import("../../types/state-machine-cat").IStateMachine}
+   */
   getAST(pScript, pOptions) {
     let lReturnValue = pScript;
 
     if (options.getOptionValue(pOptions, "inputType") === "smcat") {
       lReturnValue = parseSmCat(pScript);
     } else if (options.getOptionValue(pOptions, "inputType") === "scxml") {
+      // @ts-expect-error inputType scxml => it's a string
       lReturnValue = parseSCXML(pScript);
     } else if (typeof pScript === "string") {
       // json
@@ -29,6 +41,7 @@ export default {
 
     validateAgainstSchema($schema, lReturnValue);
 
+    // @ts-expect-error by here lReturnValue is bound to be an IStateMachine
     return lReturnValue;
   },
 };

--- a/src/parse/scxml/index.mjs
+++ b/src/parse/scxml/index.mjs
@@ -26,6 +26,11 @@ function extractActionsFromInvokes(pInvokeTriggers) {
   });
 }
 
+/**
+ * @param {import("./scxml").ISXCMLState} pState
+ * @returns {{type: string; body: string;}[]}
+ */
+
 function deriveActions(pState) {
   let lReturnValue = [];
 
@@ -43,11 +48,20 @@ function deriveActions(pState) {
   return lReturnValue;
 }
 
+/**
+ * @param {string} pType
+ * @param {import("./scxml").ISXCMLState} pState
+ * @returns {import("../../../types/state-machine-cat").StateType}
+ */
 function deriveStateType(pType, pState) {
   return pType === "history" && pState.type === "deep" ? "deephistory" : pType;
 }
 
 function mapState(pType) {
+  /**
+   * @param {import("./scxml").ISXCMLState} pState
+   * @return {import("../../../types/state-machine-cat").IState}
+   */
   return (pState) => {
     const lReturnValue = {
       name: pState.id,
@@ -73,6 +87,10 @@ function mapState(pType) {
   };
 }
 
+/**
+ * @param {import("./scxml").ISCXMLTransition} pTransition
+ * @returns {{event?: string; cond?: string; action?: string; type?: string;}}
+ */
 function extractTransitionAttributesFromObject(pTransition) {
   const lReturnValue = {};
 
@@ -95,6 +113,11 @@ function extractTransitionAttributesFromObject(pTransition) {
   return lReturnValue;
 }
 
+/**
+ *
+ * @param {import("./scxml").ISCXMLTransition} pTransition
+ * @returns {{action?: string; label?: string;event?: string; cond?: string; type?: string}}
+ */
 function extractTransitionAttributes(pTransition) {
   const lReturnValue = {};
 
@@ -120,7 +143,15 @@ function extractTransitionAttributes(pTransition) {
   return lReturnValue;
 }
 
+/**
+ * @param {import("./scxml").ISXCMLState} pState
+ */
 function reduceTransition(pState) {
+  /**
+   * @param {import("../../../types/state-machine-cat").ITransition[]} pAllTransitions
+   * @param {import("../../../types/state-machine-cat").ITransition} pTransition
+   * @returns {import("../../../types/state-machine-cat").ITransition}
+   */
   return (pAllTransitions, pTransition) => {
     // in SCXML spaces denote references to multiple states
     // => split into multiple transitions
@@ -139,6 +170,10 @@ function reduceTransition(pState) {
   };
 }
 
+/**
+ * @param {import("./scxml").ISXCMLState[]} pStates
+ * @returns {import("../../../types/state-machine-cat").ITransition[]}
+ */
 function extractTransitions(pStates) {
   return pStates
     .filter((pState) =>
@@ -156,6 +191,10 @@ function extractTransitions(pStates) {
     );
 }
 
+/**
+ * @param {import("./scxml").ISCXMLMachine} pMachine
+ * @returns {import("../../../types/state-machine-cat").IStateMachine}
+ */
 function mapMachine(pMachine) {
   const lMachine = normalizeMachine(pMachine);
   const lReturnValue = {};
@@ -181,7 +220,7 @@ function mapMachine(pMachine) {
  * Parses SCXML into a state machine AST.
  *
  * @param {string} pSCXMLString The SCXML to parse
- * @returns {IStateMachine} state machine AST
+ * @returns {import("../../../types/state-machine-cat").IStateMachine} state machine AST
  */
 export function parse(pSCXMLString) {
   const lSCXMLString = pSCXMLString.trim();

--- a/src/parse/scxml/normalize-machine.mjs
+++ b/src/parse/scxml/normalize-machine.mjs
@@ -32,7 +32,7 @@ function normalizeInitial(pMachine) {
 
   if (pMachine.initial) {
     // => it's an xml node. This detection isn't fool proof...;
-    // if it's a node but it doesn't have a transtion (which
+    // if it's a node but it doesn't have a transition (which
     // looks like an odd corner case) we won't recognize the
     // initial
     // the initial.id shouldn't occur (not allowed in scxml

--- a/src/parse/scxml/scxml.d.ts
+++ b/src/parse/scxml/scxml.d.ts
@@ -1,0 +1,93 @@
+/* eslint-disable no-use-before-define, @typescript-eslint/no-explicit-any */
+export interface ISCXMLTransition {
+  event?: string;
+  cond?: string;
+  target?: string;
+  type?: "external" | "internal";
+}
+
+export interface ISCXMLParameter {
+  name: string;
+  expr?: string;
+  location?: string;
+}
+
+export interface ISCXMLInvoke {
+  type?: string;
+  typeexpr?: string;
+  src?: string;
+  srcexpr?: string;
+  id?: string;
+  idlocation?: string;
+  namelist?: string;
+  autoforward?: boolean;
+  param?: ISCXMLParameter[];
+  finalize?: any;
+  content?: any;
+}
+
+export interface ISCXMLInitialState {
+  transition?: ISCXMLTransition; // spec: "occurs once"
+}
+
+export interface ISCXMLHistoryState {
+  id?: string;
+  type?: "shallow" | "deep";
+  transition?: ISCXMLTransition; // spec: mandatory. There's also some limitations in what the transition can have as attributes - we're ignoring that for now
+}
+
+export interface ISCXMLFinalState {
+  id?: string;
+  onentry?: string[];
+  onexit?: string[];
+  donedata?: {
+    content?: { expr?: string };
+    param?: ISCXMLParameter[];
+  };
+}
+
+export interface ISCXMLParallelState {
+  id?: string;
+  onentry?: string[];
+  onexit?: string[];
+  transition?: ISCXMLTransition[];
+  state?: ISCXMLState[];
+  parallel?: ISCXMLState[];
+  history?: ISCXMLHistoryState[];
+  datamodel?: any;
+  invoke?: (ISCXMLInvoke | string)[];
+}
+
+export interface ISCXMLState {
+  id?: string;
+  initial?: ISCXMLInitialState | string;
+  onentry?: string[];
+  onexit?: string[];
+  transition?: ISCXMLTransition[];
+  state?: ISCXMLState[];
+  parallel?: ISCXMLParallelState[];
+  final?: ISCXMLFinalState[];
+  history?: ISCXMLHistoryState[];
+  datamodel?: any;
+  invoke?: (ISCXMLInvoke | string)[];
+}
+
+export interface ISCXMLMachine {
+  // xml attributes
+  xmlns: string;
+  version: string; // spec: the value must be "1.0"
+
+  // the interesting stuff
+  name?: string;
+  initial?: ISCXMLState[] | string;
+  state?: ISCXMLState[];
+  parallel?: ISCXMLState[];
+  final?: ISCXMLState[];
+  datamodel?: string;
+  script?: any;
+  binding?: "early" | "late";
+}
+
+export interface ISCXMLAsJSON {
+  scxml?: ISCXMLMachine;
+}

--- a/src/render/dot/attributebuilder.mjs
+++ b/src/render/dot/attributebuilder.mjs
@@ -44,6 +44,13 @@ function toNameValueString(pAttribute) {
 }
 
 export default {
+  /**
+   *
+   * @param {string} pEngine
+   * @param {string} pDirection
+   * @param {*} pDotGraphAttributes
+   * @returns {string}
+   */
   buildGraphAttributes: (pEngine, pDirection, pDotGraphAttributes) =>
     GENERIC_GRAPH_ATTRIBUTES.concat(GRAPH_ATTRIBUTES[pEngine] || [])
       .concat(DIRECTION_ATTRIBUTES[pDirection] || [])

--- a/src/render/dot/counter.mjs
+++ b/src/render/dot/counter.mjs
@@ -1,18 +1,31 @@
+// @ts-check
 export default class Counter {
   constructor() {
     this.reset();
   }
 
+  /**
+   * @returns {void}
+   */
   reset() {
     this.COUNTER = 0;
   }
 
+  /**
+   * @returns {number}
+   */
   next() {
+    // @ts-expect-error TS thinks COUNTER can possibly be null as it doesn't
+    // see that the function the constructor calls ensures it won't
     // eslint-disable-next-line no-plusplus
     return ++this.COUNTER;
   }
 
+  /**
+   * @returns {string}
+   */
   nextAsString() {
+    /** @type {number} */
     const lBase = 10;
 
     return this.next().toString(lBase);

--- a/src/render/dot/render-dot-from-ast.js
+++ b/src/render/dot/render-dot-from-ast.js
@@ -1,3 +1,4 @@
+/** @type {any} - the Handlebars delivered types don't seem to cover everythint in handlebars ...*/
 const Handlebars = require("handlebars/dist/handlebars.runtime.js");
 // eslint-disable-next-line import/no-unassigned-import
 require("./dot.template.js");
@@ -15,34 +16,55 @@ Handlebars.registerHelper("stateSection", (pStateMachine) =>
 );
 
 // TODO: duplicate from the one in state-transformers.js
+/**
+ *
+ * @param {string} pString
+ * @returns {(pState: import("../../../types/state-machine-cat.js").IState) => Boolean}
+ */
 function isType(pString) {
   return (pState) => pState.type === pString;
 }
+/**
+ *
+ * @param {string[]} pStringArray
+ * @returns {(pState: import("../../../types/state-machine-cat.js").IState) => Boolean}
+ */
 // TODO: duplicate from the one in state-transformers.js
 function isOneOfTypes(pStringArray) {
   return (pState) => pStringArray.includes(pState.type);
 }
 
 // TODO: duplicate from the one in index.js
-function splitStates(pAST) {
-  pAST.initialStates = pAST.states.filter(isType("initial"));
-  pAST.regularStates = pAST.states.filter(
+function splitStates(pStateMachine) {
+  pStateMachine.initialStates = pStateMachine.states.filter(isType("initial"));
+  pStateMachine.regularStates = pStateMachine.states.filter(
     (pState) => isType("regular")(pState) && !pState.statemachine
   );
-  pAST.historyStates = pAST.states.filter(isType("history"));
-  pAST.deepHistoryStates = pAST.states.filter(isType("deephistory"));
-  pAST.choiceStates = pAST.states.filter(isType("choice"));
-  pAST.forkjoinStates = pAST.states.filter(
+  pStateMachine.historyStates = pStateMachine.states.filter(isType("history"));
+  pStateMachine.deepHistoryStates = pStateMachine.states.filter(
+    isType("deephistory")
+  );
+  pStateMachine.choiceStates = pStateMachine.states.filter(isType("choice"));
+  pStateMachine.forkjoinStates = pStateMachine.states.filter(
     isOneOfTypes(["fork", "join", "forkjoin"])
   );
-  pAST.junctionStates = pAST.states.filter(isType("junction"));
-  pAST.terminateStates = pAST.states.filter(isType("terminate"));
-  pAST.finalStates = pAST.states.filter(isType("final"));
-  pAST.compositeStates = pAST.states.filter((pState) => pState.statemachine);
+  pStateMachine.junctionStates = pStateMachine.states.filter(
+    isType("junction")
+  );
+  pStateMachine.terminateStates = pStateMachine.states.filter(
+    isType("terminate")
+  );
+  pStateMachine.finalStates = pStateMachine.states.filter(isType("final"));
+  pStateMachine.compositeStates = pStateMachine.states.filter(
+    (pState) => pState.statemachine
+  );
 
-  return pAST;
+  return pStateMachine;
 }
-
-module.exports = function renderDotFromAST(pAST) {
-  return Handlebars.templates["dot.template.hbs"](pAST);
+/**
+ * @param {import("../../../types/state-machine-cat.js").IStateMachine} pStateMachine
+ * @returns {string}
+ */
+module.exports = function renderDotFromAST(pStateMachine) {
+  return Handlebars.templates["dot.template.hbs"](pStateMachine);
 };

--- a/src/render/dot/state-transformers.mjs
+++ b/src/render/dot/state-transformers.mjs
@@ -1,3 +1,4 @@
+import cloneDeep from "lodash/cloneDeep.js";
 import utl from "./utl.mjs";
 
 function isType(pString) {
@@ -8,8 +9,9 @@ function isOneOfTypes(pStringArray) {
 }
 
 function setLabel(pState) {
-  pState.label = pState.label || pState.name;
-  return pState;
+  const lState = cloneDeep(pState);
+  lState.label = pState.label || pState.name;
+  return lState;
 }
 
 function nameNote(pState) {

--- a/src/render/dot/utl.mjs
+++ b/src/render/dot/utl.mjs
@@ -1,3 +1,9 @@
+// @ts-check
+
+/**
+ * @param {string} pString
+ * @returns {string}
+ */
 function escapeString(pString) {
   return pString
     .replace(/\\/g, "\\\\")
@@ -6,6 +12,10 @@ function escapeString(pString) {
     .concat("\\l");
 }
 
+/**
+ * @param {string} pString
+ * @returns {string}
+ */
 function escapeLabelString(pString) {
   return pString
     .replace(/\\/g, "\\\\")
@@ -14,12 +24,22 @@ function escapeLabelString(pString) {
     .concat("   \\l");
 }
 
+/**
+ * @param {string} pDirection
+ * @returns {boolean}
+ */
 function isVertical(pDirection) {
   const lDirection = pDirection || "top-down";
 
   return lDirection === "top-down" || lDirection === "bottom-top";
 }
 
+/**
+ *
+ * @param {import("../../state-machine-model.mjs").default} pStateMachineModel
+ * @param {import("../../../types/state-machine-cat").ITransition} pTransition
+ * @returns {boolean}
+ */
 function isCompositeSelf(pStateMachineModel, pTransition) {
   return (
     pTransition.from === pTransition.to &&

--- a/src/render/index-node.mjs
+++ b/src/render/index-node.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable security/detect-object-injection */
 import has from "lodash/has.js";
 import smcat from "./smcat/index.js";
@@ -7,8 +8,13 @@ import oldVector from "./vector/vector-with-viz-js.mjs";
 import scjson from "./scjson/index.mjs";
 import scxml from "./scxml/index.mjs";
 
+/**
+ *
+ * @param {import("../../types/state-machine-cat.js").OutputType} pOutputType
+ * @returns {import("../../types/state-machine-cat.js").RenderFunctionType}
+ */
 export default function getRenderFunction(pOutputType) {
-  const lOutputtype2Renderfunction = {
+  const lOutputType2RenderFunction = {
     smcat,
     dot,
     svg: vector,
@@ -24,7 +30,7 @@ export default function getRenderFunction(pOutputType) {
     scxml,
   };
 
-  return has(lOutputtype2Renderfunction, pOutputType)
-    ? lOutputtype2Renderfunction[pOutputType]
+  return has(lOutputType2RenderFunction, pOutputType)
+    ? lOutputType2RenderFunction[pOutputType]
     : (pX) => pX;
 }

--- a/src/render/index.mjs
+++ b/src/render/index.mjs
@@ -7,7 +7,7 @@ import scjson from "./scjson/index.mjs";
 import scxml from "./scxml/index.mjs";
 
 export default function getRenderFunction(pOutputType) {
-  const lOutputtype2Renderfunction = {
+  const lOutputType2RenderFunction = {
     smcat,
     dot,
     svg,
@@ -16,7 +16,7 @@ export default function getRenderFunction(pOutputType) {
     scxml,
   };
 
-  return has(lOutputtype2Renderfunction, pOutputType)
-    ? lOutputtype2Renderfunction[pOutputType]
+  return has(lOutputType2RenderFunction, pOutputType)
+    ? lOutputType2RenderFunction[pOutputType]
     : (pX) => pX;
 }

--- a/src/render/scjson/index.mjs
+++ b/src/render/scjson/index.mjs
@@ -137,6 +137,12 @@ function findInitialStateName(pStateMachine, pInitialPseudoStateName) {
   return lReturnValue;
 }
 
+/**
+ * @param {import("../../../types/state-machine-cat").IStateMachine} pStateMachine
+ * @param {import("../../../types/state-machine-cat").IRenderOptions?} _pOptions
+ * @param {import("../../../types/state-machine-cat").ITransition[]?} pTransitions
+ * @returns {any}
+ */
 export default function render(pStateMachine, _pOptions, pTransitions) {
   const lInitialPseudoStateName = findInitialPseudoStateName(pStateMachine);
   const lInitialStateName = findInitialStateName(

--- a/src/render/scjson/make-valid-xml-name.mjs
+++ b/src/render/scjson/make-valid-xml-name.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /*
  * In the XML spec we read: https://www.w3.org/TR/xml/#NT-Name:
  *
@@ -18,6 +19,11 @@ const NAME_CHAR_FORBIDDEN_RE =
 const START_NAME_CHAR_FORBIDDEN_EXTRA_RE =
   /[-|.|0-9|\u00B7|\u0300-\u036F|\u203F-\u2040]/g;
 
+/**
+ *
+ * @param {string} pCandidateNameTail
+ * @returns {string}
+ */
 function makeValidNameChars(pCandidateNameTail) {
   return pCandidateNameTail.replace(NAME_CHAR_FORBIDDEN_RE, "_");
 }
@@ -25,7 +31,7 @@ function makeValidNameChars(pCandidateNameTail) {
 /**
  * if it's an invalid NameStartChar but a valid NameChar smack a '_' in front of it
  * if it's an invalid NameChar as well - run it through the makeValidNameChars replacer
- * @param {char} pCandidateChar - start char
+ * @param {string} pCandidateChar - start char
  * @returns {string} valid start string
  */
 function makeValidNameStartChar(pCandidateChar) {

--- a/src/render/scxml/index.mjs
+++ b/src/render/scxml/index.mjs
@@ -1,6 +1,8 @@
+// @ts-check
 import ast2scjson from "../scjson/index.mjs";
 import renderFomSCJSON from "./render-from-scjson.js";
 
+/** @type {import("../../../types/state-machine-cat.js").StringRenderFunctionType} */
 export default function renderSCXML(pStateMachine) {
-  return renderFomSCJSON(ast2scjson(pStateMachine));
+  return renderFomSCJSON(ast2scjson(pStateMachine, null));
 }

--- a/src/render/vector/dot-to-vector-native.mjs
+++ b/src/render/vector/dot-to-vector-native.mjs
@@ -11,7 +11,7 @@ const DEFAULT_OPTIONS = {
  * the result
  *
  * @param  {string} pDot        The dot program as a string
- * @param  {object} pOptions
+ * @param  {{exec: string, format: import("../../../types/state-machine-cat").OutputType}} pOptions
  *         exec: the path to the executable to run. Default: 'dot'
  * @return {string} the dot program converted into an svg
  * @throws {Error} when something ontowards has happened (executable not found, erroneous dot program)

--- a/src/render/vector/vector-native-dot-with-fallback.mjs
+++ b/src/render/vector/vector-native-dot-with-fallback.mjs
@@ -10,8 +10,9 @@ const DEFAULT_INDENT = 2;
 const DOGMATIC_CONSOLE_WIDTH = 78;
 const VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS = ["pdf", "png"];
 
-export default (pAST, pOptions) => {
-  const lDotProgram = ast2dot(pAST, pOptions);
+/** @type {import("../../../types/state-machine-cat.js").StringRenderFunctionType} */
+export default (pStateMachine, pOptions) => {
+  const lDotProgram = ast2dot(pStateMachine, pOptions);
   const lDotOptions = {
     engine: options.getOptionValue(pOptions, "engine"),
     format: options.getOptionValue(pOptions, "outputType"),

--- a/src/render/vector/vector-with-viz-js.mjs
+++ b/src/render/vector/vector-with-viz-js.mjs
@@ -8,8 +8,9 @@ const OUTPUT_TYPE2FORMAT = {
   oldeps: "eps",
 };
 
-export default (pAST, pOptions) =>
-  viz(ast2dot(pAST, pOptions), {
+/** @type {import("../../../types/state-machine-cat.js").StringRenderFunctionType} */
+export default (pStateMachine, pOptions) =>
+  viz(ast2dot(pStateMachine, pOptions), {
     engine: options.getOptionValue(pOptions, "engine"),
     format:
       OUTPUT_TYPE2FORMAT[options.getOptionValue(pOptions, "outputType")] ||

--- a/src/state-machine-model.mjs
+++ b/src/state-machine-model.mjs
@@ -1,3 +1,9 @@
+// @ts-check
+/**
+ * @param {import("../types/state-machine-cat").IState[]} pStates
+ * @param {boolean} pHasParent
+ * @returns {any} // IFlattenedState  - a state, but flattened (statemachine is a boolean, the new attr hasParent as well)
+ */
 function flattenStates(pStates, pHasParent = false) {
   let lReturnValue = [];
 
@@ -6,6 +12,8 @@ function flattenStates(pStates, pHasParent = false) {
     .forEach((pState) => {
       if (Object.prototype.hasOwnProperty.call(pState.statemachine, "states")) {
         lReturnValue = lReturnValue.concat(
+          // @ts-expect-error TS doesn't detect that after the call in the filter
+          // the .statemachine is guaranteed to exist
           flattenStates(pState.statemachine.states, true)
         );
       }
@@ -21,10 +29,17 @@ function flattenStates(pStates, pHasParent = false) {
   );
 }
 
+/**
+ * @param {import("../types/state-machine-cat").IStateMachine} pStateMachine
+ * @returns {import("../types/state-machine-cat").ITransition[]}
+ */
 function flattenTransitions(pStateMachine) {
+  /** @type {import("../types/state-machine-cat").ITransition[]} */
   let lTransitions = [];
 
   if (Object.prototype.hasOwnProperty.call(pStateMachine, "transitions")) {
+    // @ts-expect-error TS doesn't detect that after the call in the if the
+    // .transitions is guaranteed to exist
     lTransitions = pStateMachine.transitions;
   }
   if (Object.prototype.hasOwnProperty.call(pStateMachine, "states")) {
@@ -32,6 +47,8 @@ function flattenTransitions(pStateMachine) {
       .filter((pState) => Boolean(pState.statemachine))
       .forEach((pState) => {
         lTransitions = lTransitions.concat(
+          // @ts-expect-error TS doesn't detect that after the call in the filter
+          // the .statemachine is guaranteed to exist
           flattenTransitions(pState.statemachine)
         );
       });
@@ -40,25 +57,42 @@ function flattenTransitions(pStateMachine) {
 }
 
 export default class StateMachineModel {
-  constructor(pAST) {
-    this._flattenedStates = flattenStates(pAST.states || []);
-    this._flattenedTransitions = flattenTransitions(pAST);
+  /**
+   * @param {import("../types/state-machine-cat").IStateMachine} pStateMachine
+   */
+  constructor(pStateMachine) {
+    this._flattenedStates = flattenStates(pStateMachine.states || []);
+    this._flattenedTransitions = flattenTransitions(pStateMachine);
   }
-
+  /**
+   * @returns {import("../types/state-machine-cat").ITransition[]}
+   */
   get flattenedTransitions() {
     return this._flattenedTransitions;
   }
 
+  /**
+   * @param {string} pName
+   * @returns {any} // IFlattenedState
+   */
   findStateByName(pName) {
     return this._flattenedStates.find((pState) => pState.name === pName);
   }
 
+  /**
+   * @param {import("../types/state-machine-cat").StateType[]} pTypes
+   * @returns {any} // IFlattenedState
+   */
   findStatesByTypes(pTypes) {
     return this._flattenedStates.filter((pState) =>
       pTypes.includes(pState.type)
     );
   }
 
+  /**
+   * @param {string} pStateName
+   * @returns {import("../types/state-machine-cat").ITransition[]}
+   */
   findExternalSelfTransitions(pStateName) {
     return this._flattenedTransitions.filter(
       (pTransition) =>
@@ -68,12 +102,20 @@ export default class StateMachineModel {
     );
   }
 
+  /**
+   * @param {string} pFromStateName
+   * @returns {import("../types/state-machine-cat").ITransition[]}
+   */
   findTransitionsByFrom(pFromStateName) {
     return this._flattenedTransitions.filter(
       (pTransition) => pTransition.from === pFromStateName
     );
   }
 
+  /**
+   * @param {string} pToStateName
+   * @returns {import("../types/state-machine-cat").ITransition[]}
+   */
   findTransitionsByTo(pToStateName) {
     return this._flattenedTransitions.filter(
       (pTransition) => pTransition.to === pToStateName

--- a/src/transform/utl.mjs
+++ b/src/transform/utl.mjs
@@ -1,3 +1,11 @@
+// @ts-check
+/**
+ *
+ * @param {string|undefined} pEvent
+ * @param {string|undefined} pCond
+ * @param {string|undefined} pActions
+ * @returns {string}
+ */
 function formatLabel(pEvent, pCond, pActions) {
   let lReturnValue = "";
 

--- a/test/cli/normalize.spec.mjs
+++ b/test/cli/normalize.spec.mjs
@@ -13,6 +13,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -27,6 +28,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -41,6 +43,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -55,6 +58,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -69,6 +73,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -84,6 +89,7 @@ describe("#cli - normalize", () => {
         dotGraphAttrs: [],
         dotNodeAttrs: [],
         dotEdgeAttrs: [],
+        desugar: false,
       }
     );
   });
@@ -104,6 +110,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -118,6 +125,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -132,6 +140,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -148,6 +157,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -173,6 +183,7 @@ describe("#cli - normalize", () => {
       ],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -187,6 +198,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -201,6 +213,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -215,6 +228,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 
@@ -229,6 +243,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      desugar: false,
     });
   });
 });

--- a/types/state-machine-cat.d.ts
+++ b/types/state-machine-cat.d.ts
@@ -183,13 +183,22 @@ export function getAllowedValues(): IAllowedValues;
 export type InputType = "smcat" | "json" | "scxml";
 
 export type OutputType =
-  | "smcat"
-  | "dot"
-  | "json"
   | "ast"
-  | "svg"
+  | "dot"
+  | "eps"
+  | "json"
+  | "oldeps"
+  | "oldps"
+  | "oldps2"
+  | "oldsvg"
+  | "pdf"
+  | "png"
+  | "ps"
+  | "ps2"
   | "scjson"
-  | "scxml";
+  | "scxml"
+  | "smcat"
+  | "svg";
 
 export type EngineType = "dot" | "circo" | "fdp" | "neato" | "osage" | "twopi";
 
@@ -204,7 +213,7 @@ export type dotAttributesType = {
   value: string;
 }[];
 
-export interface IRenderOptions {
+export interface IBaseRenderOptions {
   /**
    * How to interpret the input (defaults to 'smcat')
    */
@@ -223,6 +232,17 @@ export interface IRenderOptions {
    */
   direction?: DirectionType;
   /**
+   * If true state machine cat will replace 'sugar' pseudo states
+   * (choice, forks and junctions) with their equivalent meaning
+   * (defaults to false).
+   *
+   * For details: https://github.com/sverweij/state-machine-cat/blob/master/docs/desugar.md
+   */
+  desugar?: boolean;
+}
+
+export interface IRenderOptions extends IBaseRenderOptions {
+  /**
    * For the 'dot' renderer: Graph attributes to the engine
    */
   dotGraphAttrs?: dotAttributesType;
@@ -234,18 +254,25 @@ export interface IRenderOptions {
    * For the 'dot' renderer: Edge attributes to the engine
    */
   dotEdgeAttrs?: dotAttributesType;
-  /**
-   * If true state machine cat will replace 'sugar' pseudo states
-   * (choice, forks and junctions) with their equivalent meaning
-   * (defaults to false).
-   *
-   * For details: https://github.com/sverweij/state-machine-cat/blob/master/docs/desugar.md
-   */
-  desugar?: boolean;
 }
 
+export type StringRenderFunctionType = (
+  pScript: IStateMachine,
+  pOptions: IRenderOptions
+) => string;
+
+export type WhateverRenderFunctionType = (
+  pScript: IStateMachine,
+  pOptions: IRenderOptions
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => any;
+
+export type RenderFunctionType =
+  | StringRenderFunctionType
+  | WhateverRenderFunctionType;
+
 /**
- * Translates the input script to an outputscript.
+ * Translates the input script to an output script.
  *
  * @param pScript     The script to translate
  * @param pOptions    options influencing parsing & rendering.


### PR DESCRIPTION
## Description

- adds types-as-comments in javascript files and puts the @ ts-check thing in them so they're indeed checked
- updates the existing type definitions + adds a few new ones

This PR is a part 1 of several. This PR covers:
- bin & cli
- general modules in src
- transform
- parse - except for scxml which is partly typed
- transform
- render: the smcat renderer

TODO (for in a separate PR):
- the renderers
- the scxml parser

For both of these we'll need to describe the scjson schema (type).
The dot massaging code will need a separate .d.ts as well

## Motivation and Context

First step in migrating the code base to TypeScript

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
