### PR TITLE
chore(ci): set up diff graph output in GHA step summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+        if: github.event_name == 'pull_request' && matrix.node-version == env.NODE_LATEST
+      - uses: actions/checkout@v3
+        with: 
+          fetch-depth: 1
+        if: github.event_name != 'pull_request' || matrix.node-version != env.NODE_LATEST
       - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
@@ -48,17 +53,6 @@ jobs:
         run: |
           npm run depcruise
           npm run lint
-      - name: on pushes to the default branch emit full depcruise results to step summary
-        if: always() && matrix.node-version == env.NODE_LATEST && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
-        run: |
-          npm run depcruise:github-actions:markdown
-          npm run depcruise:github-actions:mermaid
-      - name: on pull requests emit depcruise results + diff graph to step summary
-        if: always() && matrix.node-version == env.NODE_LATEST && github.event_name == 'pull_request' && github.ref_name != github.event.repository.default_branch
-        run: |
-          npm run depcruise:github-actions:markdown
-          export SHA=${{github.event.pull_request.base.sha}} && npm run depcruise:github-actions:mermaid:affected
-          export SHA=${{github.event.pull_request.base.sha}} && npm run depcruise:github-actions:mermaid:diff
       - name: test (on node != ${{env.NODE_LATEST}} only)
         if: matrix.node-version != env.NODE_LATEST
         run: npm test
@@ -70,6 +64,29 @@ jobs:
         uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_COVERAGE_ID }}
+      - name: emit coverage results & depcruise result to step summary
+        if: always() && matrix.node-version == env.NODE_LATEST
+        run: |
+          echo '## Code coverage' >> $GITHUB_STEP_SUMMARY
+          node tools/istanbul-json-summary-to-markdown.mjs < coverage/coverage-summary.json >> $GITHUB_STEP_SUMMARY
+          yarn --silent depcruise:github-actions:markdown >> $GITHUB_STEP_SUMMARY
+      - name: on pushes to the default branch emit graph to the step summary
+        if: always() && matrix.node-version == env.NODE_LATEST && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        run: |
+          echo '## Visual overview' >> $GITHUB_STEP_SUMMARY
+          echo '```mermaid' >> $GITHUB_STEP_SUMMARY
+          yarn --silent depcruise:github-actions:mermaid >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: on pull requests emit depcruise graph to step summary with changed modules highlighted
+        if: always() && matrix.node-version == env.NODE_LATEST && github.event_name == 'pull_request' && github.ref_name != github.event.repository.default_branch
+        run: |
+          echo '## Visual diff' >> $GITHUB_STEP_SUMMARY
+          echo Modules changed in this PR have a fluorescent green color. All other modules in the graph are those directly or indirectly affected by changes in the green modules. >> $GITHUB_STEP_SUMMARY
+          echo '```mermaid' >> $GITHUB_STEP_SUMMARY
+          SHA=${{github.event.pull_request.base.sha}} yarn --silent depcruise:github-actions:mermaid:affected >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
   check-windows:
     env:
@@ -90,25 +107,3 @@ jobs:
       - uses: google/wireit@setup-github-actions-caching/v1
       - run: npm install
       - run: npm test
-
-  codeql:
-    name: CodeQL
-    needs: [check-linux, check-windows]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: github/codeql-action/init@v2
-        with:
-          languages: "javascript"
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-      - uses: github/codeql-action/analyze@v2

--- a/package.json
+++ b/package.json
@@ -38,10 +38,9 @@
     "depcruise:graph:dev": "wireit",
     "depcruise:graph:dev:flat": "wireit",
     "depcruise:view-report": "wireit",
-    "depcruise:github-actions:markdown": "wireit",
-    "depcruise:github-actions:mermaid": "wireit",
-    "depcruise:github-actions:mermaid:affected": "wireit",
-    "depcruise:github-actions:mermaid:diff": "wireit",
+    "depcruise:github-actions:markdown": "depcruise bin src test types --config config/dependency-cruiser.js --output-type markdown",
+    "depcruise:github-actions:mermaid": "depcruise bin src --include-only '^(bin|src)' --config config/dependency-cruiser.js --output-type mermaid",
+    "depcruise:github-actions:mermaid:affected": "depcruise bin src test types tools --config config/dependency-cruiser.js --output-type mermaid --reaches \"$(watskeburt $SHA -T regex)\"",
     "lint": "wireit",
     "lint:eslint": "wireit",
     "lint:prettier": "wireit",
@@ -256,30 +255,6 @@
         "depcruise:json"
       ]
     },
-    "depcruise:github-actions:markdown": {
-      "command": "depcruise-fmt node_modules/.cache/depcruise-cache.json --output-type markdown >> $GITHUB_STEP_SUMMARY",
-      "dependencies": [
-        "depcruise:json"
-      ]
-    },
-    "depcruise:github-actions:mermaid": {
-      "command": "echo '\n\n```mermaid' >> $GITHUB_STEP_SUMMARY && depcruise-fmt node_modules/.cache/depcruise-cache.json --include-only '^(bin|src)' --output-type mermaid >> $GITHUB_STEP_SUMMARY && echo '```\n\n' >> $GITHUB_STEP_SUMMARY",
-      "dependencies": [
-        "depcruise:json"
-      ]
-    },
-    "depcruise:github-actions:mermaid:affected": {
-      "command": "echo '\n\n```mermaid' >> $GITHUB_STEP_SUMMARY && depcruise-fmt node_modules/.cache/depcruise-cache.json --include-only --reaches '$(watskeburt $SHA -T regex)' --output-type mermaid >> $GITHUB_STEP_SUMMARY && echo '```\n\n' >> $GITHUB_STEP_SUMMARY",
-      "dependencies": [
-        "depcruise:json"
-      ]
-    },
-    "depcruise:github-actions:mermaid:diff": {
-      "command": "echo '\n\n```mermaid' >> $GITHUB_STEP_SUMMARY && depcruise-fmt node_modules/.cache/depcruise-cache.json --include-only '^(bin|src)' --highlight '$(watskeburt $SHA -T regex)' --output-type mermaid >> $GITHUB_STEP_SUMMARY && echo '```\n\n' >> $GITHUB_STEP_SUMMARY",
-      "dependencies": [
-        "depcruise:json"
-      ]
-    },
     "lint": {
       "dependencies": [
         "lint:eslint",
@@ -367,9 +342,10 @@
       ]
     },
     "test:cover": {
-      "command": "c8 --all --check-coverage --statements 100 --branches 99.1 --functions 100 --lines 100 --exclude \"{bin/*,config/**/*,coverage/**/*,docs/**/*,public/**/*,test/**/*,tools/**/*,types/**/*,dist/commonjs/*,src/**/*.d.{ts,mts},src/**/*{template,-parser}.{mjs,cjs,js},tmp*}\" --reporter text-summary --reporter html --reporter lcov mocha",
+      "command": "c8 --all --check-coverage --statements 100 --branches 99.1 --functions 100 --lines 100 --exclude \"{bin/*,config/**/*,coverage/**/*,docs/**/*,public/**/*,test/**/*,tools/**/*,types/**/*,dist/commonjs/*,src/**/*.d.{ts,mts},src/**/*{template,-parser}.{mjs,cjs,js},tmp*}\" --reporter text-summary --reporter html --reporter lcov --reporter json-summary mocha",
       "output": [
-        "coverage/lcov.info"
+        "coverage/lcov.info",
+        "coverage/coverage-summary.json"
       ],
       "files": [
         "{src,test}/**/*.{js,mjs,json}"

--- a/src/parse/parser-helpers.mjs
+++ b/src/parse/parser-helpers.mjs
@@ -57,7 +57,7 @@ function matches(pName) {
 }
 
 /**
- * @param {string} pName
+ * @param {string} [pName]
  * @returns {import("../../types/state-machine-cat.js").StateType}
  */
 function getStateType(pName) {
@@ -85,7 +85,7 @@ function isComposite(pState) {
 }
 
 /**
- * @param {import("../../types/state-machine-cat.js").IStateMachine|undefined} pStateMachine
+ * @param {import("../../types/state-machine-cat.js").IStateMachine} [pStateMachine]
  * @returns {string[]}
  */
 function getAlreadyDeclaredStates(pStateMachine) {

--- a/src/parse/scxml/scxml.d.ts
+++ b/src/parse/scxml/scxml.d.ts
@@ -1,4 +1,187 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-explicit-any */
+
+/**
+ * These data types are based on the w3 scxml specification
+ * https://www.w3.org/TR/scxml/#Basic
+ */
+
+export interface ISCXMLAsJSON {
+  scxml?: any;
+}
+
+export interface ISCXMLMetaAttributes {
+  xmlns: "http://www.w3.org/2005/07/scxml";
+
+  version: "1.0";
+
+  /**
+   * The datamodel that this document requires. "null" denotes the Null
+   * datamodel, "ecmascript" the ECMAScript datamodel, and "xpath" the
+   * XPath datamodel, as defined in B Data Models.
+   *
+   * Note: in the SCXML spec datamodel is both an attribute (this one)
+   * and a _child_. To prevent duplicate keys we've _renamed_ the datamodel
+   * attribute to datamodelType.
+   */
+  datamodelType?: "null" | "ecmascript" | "xpath" | string;
+
+  /**
+   * The data binding to use.
+   * See [5.3.3 Data Binding](https://www.w3.org/TR/scxml/#DataBinding) for details.
+   */
+  binding?: "early" | "late";
+
+  /**
+   * Defines part or all of the data model.
+   */
+  datamodel?: string;
+
+  /**
+   * Provides scripting capability.
+   */
+  script?: any;
+}
+
+/**
+ * W3 specification: [3.2 - scxml](https://www.w3.org/TR/scxml/#scxml)
+ */
+export interface INormalizedSCXMLMachine extends ISCXMLMetaAttributes {
+  /**
+   * The id of the default initial state (or states) for this state.
+   *
+   * Valid values: A legal state specification.
+   *
+   * In the spec it can be either an attribute xor a child
+   */
+  initial: ISCXMLInitialState[];
+
+  /**
+   * A compound or atomic state.
+   */
+  state: INormalizedSCXMLState[];
+
+  /**
+   * A parallel state.
+   */
+  parallel: ISCXMLParallelState[];
+
+  /**
+   * A top-level final state in the state machine.
+   * The SCXML processor must terminate processing when the state machine
+   * reaches this state.
+   */
+  final: ISCXMLFinalState[];
+
+  /**
+   * In SCXML the top level object does not have an id. However, we use
+   * SCXMLMachines nested into (sub)states, and there they're massively useful -
+   * hence allowed nonetheless
+   */
+  id?: string;
+
+  /**
+   * In SCXML the top level no history state can be specified. As we're re-using
+   * the ISCXMLMachine for nesting we allow it nonetheless.
+   */
+  history: ISCXMLHistoryState[];
+
+  /**
+   * The name of this state machine. It is for purely informational purposes.
+   *
+   * Valid values: any valid NMTOKEN
+   */
+  name?: string;
+}
+
+/**
+ * W3 specification: [3.3 - state](https://www.w3.org/TR/scxml/#state)
+ */
+export interface INormalizedSCXMLState {
+  /**
+   * The identifier for this state. See [3.14 IDs](https://www.w3.org/TR/scxml/#IDs)
+   * for details.
+   *
+   * Valid values: A valid id as defined in [XML Schema](https://www.w3.org/TR/scxml/#Schema)
+   */
+  id?: string;
+
+  /**
+   * The id of the default initial state (or states) for this state.
+   *
+   * Valid values: A legal state specification.
+   *
+   * In the spec it can be either an attribute xor a child
+   */
+  initial?: ISCXMLInitialState | string;
+
+  /**
+   * Optional element holding executable content to be run upon entering
+   * this state. [3.4 - onentry](https://www.w3.org/TR/scxml/#onentry)
+   */
+  onentry?: string[];
+
+  /**
+   * Optional element holding executable content to be run when exiting
+   * this state. [3.4 - onexit](https://www.w3.org/TR/scxml/#onexit)
+   */
+  onexit?: string[];
+
+  /**
+   * Defines an outgoing transition from this state.
+   */
+  transition?: ISCXMLTransition[];
+
+  /**
+   * Defines a sequential substate of the parent state.
+   */
+  state?: INormalizedSCXMLState[];
+
+  /**
+   * Defines a parallel substate.
+   */
+  parallel?: ISCXMLParallelState[];
+
+  /**
+   * Defines a final substate.
+   */
+  final?: ISCXMLFinalState[];
+
+  /**
+   * A child pseudo-state which records the descendant state(s) that the
+   * parent state was in the last time the system transitioned from the
+   * parent.
+   */
+  history?: ISCXMLHistoryState[];
+
+  /**
+   * Defines part or all of the data model.
+   */
+  datamodel?: any;
+
+  /**
+   * Invokes an external service.
+   */
+  invoke?: (ISCXMLInvoke | string)[];
+}
+
+/**
+ * W3 specification: [3.4 - parallel](https://www.w3.org/TR/scxml/#parallel)
+ */
+export interface ISCXMLParallelState {
+  id?: string;
+  onentry?: string[];
+  onexit?: string[];
+  transition?: ISCXMLTransition[];
+  state?: INormalizedSCXMLState[];
+  parallel?: INormalizedSCXMLState[];
+  history?: ISCXMLHistoryState[];
+  datamodel?: any;
+  invoke?: (ISCXMLInvoke | string)[];
+}
+
+/**
+ * W3 specification: [3.5 - transition](https://www.w3.org/TR/scxml/#transition)
+ */
 export interface ISCXMLTransition {
   event?: string;
   cond?: string;
@@ -6,12 +189,93 @@ export interface ISCXMLTransition {
   type?: "external" | "internal";
 }
 
+/**
+ * W3 specification: [3.6 - initial](https://www.w3.org/TR/scxml/#initial)
+ */
+export interface ISCXMLInitialState {
+  /**
+   * The id for the `<initial>` state is _not_ part of the SCXML specification.
+   * However, we use it anyway for convenience and consistency.
+   */
+  id: string;
+  /**
+   * A transition whose 'target' specifies the default initial state(s).
+   * Occurs once. In a conformant SCXML document, this transition must not
+   * contain 'cond' or 'event' attributes, and must specify a non-null 'target'
+   * whose value is a valid state specification consisting solely of descendants
+   * of the containing state (see
+   * [3.11 Legal State Configurations and Specifications](https://www.w3.org/TR/scxml/#LegalStateConfigurations)
+   * for details) This transition _may_ contain executable content.
+   *
+   * According to the specification can occur once. For convenience and
+   * consistency with other states we allow more than one, though.
+   */
+  transition?: ISCXMLTransition[];
+}
+
+/**
+ * W3 specification: [3.7 - final](https://www.w3.org/TR/scxml/#final)
+ */
+export interface ISCXMLFinalState {
+  id?: string;
+  onentry?: string[];
+  onexit?: string[];
+  donedata?: {
+    content?: { expr?: string };
+    param?: ISCXMLParameter[];
+  };
+}
+
+/**
+ * W3 specification: [3.10 - history](https://www.w3.org/TR/scxml/#history)
+ */
+export interface ISCXMLHistoryState {
+  /**
+   * The identifier for this pseudo state. See [3.14 IDs](https://www.w3.org/TR/scxml/#IDs)
+   * for details.
+   */
+  id?: string;
+
+  /**
+   * Determines whether the active atomic substate(s) of the current state or
+   * only its immediate active substate(s) are recorded.
+   */
+  type?: "shallow" | "deep";
+
+  /**
+   * A transition whose 'target' specifies the default history configuration.
+   * In a conformant SCXML document, this transition must not contain 'cond'
+   * or 'event' attributes, and must specify a non-null 'target' whose value is
+   * a valid state specification (see
+   * [3.11 Legal State Configurations and Specifications](https://www.w3.org/TR/scxml/#LegalStateConfigurations)
+   * for details) This transition _may_ contain executable content.
+   *
+   * If 'type' is "shallow", then the 'target' of this `<transition>` must contain
+   * only immediate children of the parent state. Otherwise it must contain only
+   * descendants of the parent.
+   *
+   * Occurs once. (Note that under the definition of a legal state specification,
+   * if the parent of the history element is `<state>` and the default state
+   * specification contains a multiple states, then, in a conformant SCXML
+   * document, the 'type' of the history element must be "deep" and the states
+   * must be atomic descendants of a `<parallel>` element that is itself a
+   * descendant of the parent `<state>` element.)
+   */
+  transition?: ISCXMLTransition;
+}
+
+/**
+ * W3 specification: [5.7 - param](https://www.w3.org/TR/scxml/#param)
+ */
 export interface ISCXMLParameter {
   name: string;
   expr?: string;
   location?: string;
 }
 
+/**
+ * W3 specification: [6.4 - invoke](https://www.w3.org/TR/scxml/#invoke)
+ */
 export interface ISCXMLInvoke {
   type?: string;
   typeexpr?: string;
@@ -24,70 +288,4 @@ export interface ISCXMLInvoke {
   param?: ISCXMLParameter[];
   finalize?: any;
   content?: any;
-}
-
-export interface ISCXMLInitialState {
-  transition?: ISCXMLTransition; // spec: "occurs once"
-}
-
-export interface ISCXMLHistoryState {
-  id?: string;
-  type?: "shallow" | "deep";
-  transition?: ISCXMLTransition; // spec: mandatory. There's also some limitations in what the transition can have as attributes - we're ignoring that for now
-}
-
-export interface ISCXMLFinalState {
-  id?: string;
-  onentry?: string[];
-  onexit?: string[];
-  donedata?: {
-    content?: { expr?: string };
-    param?: ISCXMLParameter[];
-  };
-}
-
-export interface ISCXMLParallelState {
-  id?: string;
-  onentry?: string[];
-  onexit?: string[];
-  transition?: ISCXMLTransition[];
-  state?: ISCXMLState[];
-  parallel?: ISCXMLState[];
-  history?: ISCXMLHistoryState[];
-  datamodel?: any;
-  invoke?: (ISCXMLInvoke | string)[];
-}
-
-export interface ISCXMLState {
-  id?: string;
-  initial?: ISCXMLInitialState | string;
-  onentry?: string[];
-  onexit?: string[];
-  transition?: ISCXMLTransition[];
-  state?: ISCXMLState[];
-  parallel?: ISCXMLParallelState[];
-  final?: ISCXMLFinalState[];
-  history?: ISCXMLHistoryState[];
-  datamodel?: any;
-  invoke?: (ISCXMLInvoke | string)[];
-}
-
-export interface ISCXMLMachine {
-  // xml attributes
-  xmlns: string;
-  version: string; // spec: the value must be "1.0"
-
-  // the interesting stuff
-  name?: string;
-  initial?: ISCXMLState[] | string;
-  state?: ISCXMLState[];
-  parallel?: ISCXMLState[];
-  final?: ISCXMLState[];
-  datamodel?: string;
-  script?: any;
-  binding?: "early" | "late";
-}
-
-export interface ISCXMLAsJSON {
-  scxml?: ISCXMLMachine;
 }

--- a/tools/istanbul-json-summary-to-markdown.mjs
+++ b/tools/istanbul-json-summary-to-markdown.mjs
@@ -1,0 +1,45 @@
+function formatMetric(pCoverageMetric) {
+  return `${pCoverageMetric.pct.toFixed(1)}%|${pCoverageMetric.covered}/${
+    pCoverageMetric.total
+  }|${pCoverageMetric.skipped} skipped`;
+}
+
+function formatSummary(pCoverageSummary) {
+  return (
+    `|||||\n` +
+    `|:--|--:|:--:|--:|\n` +
+    `|**Statements**|${formatMetric(pCoverageSummary.total.statements)}|\n` +
+    `|**Branches**|${formatMetric(pCoverageSummary.total.branches)}|\n` +
+    `|**Functions**|${formatMetric(pCoverageSummary.total.functions)}|\n` +
+    `|**Lines**|${formatMetric(pCoverageSummary.total.lines)}|\n`
+  );
+}
+/**
+ * Takes the output from the instanbul json-summary reporter (in a readStream),
+ * formats it in a markdown table and writes it to the provided writeStream
+ *
+ * @param {readStream} pStream stream to read the JSON from
+ * @param {writeStream} pOutStream stream to write the markdown to
+ */
+function main(pInStream, pOutStream) {
+  let lBuffer = "";
+
+  pInStream
+    .on("end", () => {
+      pOutStream.write(formatSummary(JSON.parse(lBuffer)));
+      pOutStream.end();
+    })
+    .on(
+      "error",
+      /* c8 ignore start */
+      (pError) => {
+        process.stderr.write(`${pError}\n`);
+      }
+      /* c8 ignore stop */
+    )
+    .on("data", (pChunk) => {
+      lBuffer += pChunk;
+    });
+}
+
+main(process.stdin, process.stdout);


### PR DESCRIPTION
## Description

- set up diff graph output in GHA step summary
- also removes the CodeQL action as part of PR's (it never uncovered anything and it is not fast about it - having it in a nightly is more than enough until further notice).

## Motivation and Context

There was something like that in already - but made it consistent with the setup in my other repos.

## How Has This Been Tested?

- [x] by creating a PR (see [action run result while it ain't reaped](https://github.com/sverweij/state-machine-cat/actions/runs/3772728667))

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
