### PR TITLE
refactor(test): replaces chai-xml, chai-json-schema with (chai-less) alternatives

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
   },
   "devDependencies": {
     "@types/chai": "4.3.5",
-    "@types/chai-xml": "0.3.2",
     "@types/he": "1.2.0",
     "@types/lodash": "4.14.196",
     "@types/mocha": "10.0.1",
@@ -113,9 +112,6 @@
     "@typescript-eslint/parser": "6.2.1",
     "c8": "8.0.1",
     "chai": "4.3.7",
-    "chai-as-promised": "7.1.1",
-    "chai-json-schema": "1.5.1",
-    "chai-xml": "0.4.1",
     "dependency-cruiser": "13.1.1",
     "esbuild": "0.18.17",
     "eslint": "8.46.0",

--- a/test/bin.spec.mts
+++ b/test/bin.spec.mts
@@ -1,10 +1,5 @@
 import { spawnSync } from "node:child_process";
-import chai from "chai";
-import chaiXML from "chai-xml";
-
-const expect = chai.expect;
-
-chai.use(chaiXML);
+import { strictEqual } from "node:assert";
 
 describe("e2e", () => {
   it("by default renders an svg from an smcat program", () => {
@@ -14,8 +9,8 @@ describe("e2e", () => {
       "-o",
       "-",
     ]);
-    expect(status).to.equal(0);
-    expect(stdout.toString("utf8")).to.contain("<svg ");
-    expect(stdout.toString("utf8")).to.contain("</svg>");
+    strictEqual(status, 0);
+    strictEqual(stdout.toString("utf8").includes("<svg"), true);
+    strictEqual(stdout.toString("utf8").includes("</svg>"), true);
   });
 });

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -1,14 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
+import { expect } from "chai";
 import * as actions from "../../src/cli/actions.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const expect = chai.expect;
-
-chai.use(chaiAsPromised);
 
 const testPairs = [
   {
@@ -50,11 +46,11 @@ const testPairs = [
 ].map((pTestPair) => {
   pTestPair.input.options.inputFrom = path.join(
     __dirname,
-    pTestPair.input.options.inputFrom
+    pTestPair.input.options.inputFrom,
   );
   pTestPair.input.options.outputTo = path.join(
     __dirname,
-    pTestPair.input.options.outputTo
+    pTestPair.input.options.outputTo,
   );
   pTestPair.expected = path.join(__dirname, pTestPair.expected);
   return pTestPair;
@@ -109,7 +105,7 @@ describe("#cli - actions", () => {
   describe("formatError()", () => {
     it("returns the message of non-syntax errors", () => {
       expect(actions.formatError(new Error("hatsikidee!"))).to.equal(
-        "hatsikidee!"
+        "hatsikidee!",
       );
     });
 
@@ -124,7 +120,7 @@ describe("#cli - actions", () => {
       };
 
       expect(actions.formatError(lError)).to.equal(
-        `\n  syntax error on line 481, column 69:\n  Make my day!\n\n`
+        `\n  syntax error on line 481, column 69:\n  Make my day!\n\n`,
       );
     });
   });

--- a/test/index.spec.mts
+++ b/test/index.spec.mts
@@ -1,13 +1,12 @@
-import chai from "chai";
-import chaiXML from "chai-xml";
+import { expect } from "chai";
+import fastxml from "fast-xml-parser";
 import smcat from "../src/index.mjs";
 import smcat_node from "../src/index-node.mjs";
 import options from "../src/options.mjs";
 import { createRequireJSON } from "./utl.mjs";
 
-chai.use(chaiXML);
-const expect = chai.expect;
 const $package = createRequireJSON(import.meta.url)("../package.json");
+const gXMLParser = new fastxml.XMLParser();
 
 describe("integration - regular esm", () => {
   it("returned version corresponds with the package's", () => {
@@ -19,39 +18,43 @@ describe("integration - regular esm", () => {
       smcat.render("a;\n", {
         inputType: "smcat",
         outputType: "smcat",
-      })
+      }),
     ).to.equal("a;\n\n");
   });
 
   it("returns svg and assumes smcat when no options passed", () => {
-    expect(smcat.render("a;\n", null)).xml.to.be.valid();
+    const lXML = smcat.render("a;\n", null);
+    gXMLParser.parse(lXML, true);
   });
 
   it("returns svg when no outputType specified", () => {
-    expect(
+    gXMLParser.parse(
       smcat.render("a;\n", {
         inputType: "smcat",
-      })
-    ).xml.to.be.valid;
+      }),
+      true,
+    );
   });
 
   it("returns svg when svg specified as output", () => {
-    expect(
+    gXMLParser.parse(
       smcat.render("a;\n", {
         inputType: "smcat",
         outputType: "svg",
-      })
-    ).xml.to.be.valid();
+      }),
+      true,
+    );
   });
 
   it("returns svg rendered with another engine when that is specified ('neato' here)", () => {
-    expect(
+    gXMLParser.parse(
       smcat.render("a=>b;b=>c;c=>a;", {
         inputType: "smcat",
         outputType: "svg",
         engine: "neato",
-      })
-    ).xml.to.be.valid();
+      }),
+      true,
+    );
   });
 
   it("accepts json as input", () => {
@@ -59,7 +62,7 @@ describe("integration - regular esm", () => {
       smcat.render('{"states":[{"name":"a", "type":"regular"}]}', {
         inputType: "json",
         outputType: "smcat",
-      })
+      }),
     ).to.equal("a;\n\n");
   });
 
@@ -86,8 +89,8 @@ describe("integration - regular esm", () => {
         {
           inputType: "json",
           outputType: "smcat",
-        }
-      )
+        },
+      ),
     ).to.equal("a;\n\n");
   });
 
@@ -105,7 +108,7 @@ describe("integration - regular esm", () => {
         {
           inputType: "json",
           outputType: "smcat",
-        }
+        },
       );
     }).to.throw();
   });
@@ -115,7 +118,7 @@ describe("integration - regular esm", () => {
       smcat.render("a;", {
         inputType: "smcat",
         outputType: "json",
-      })
+      }),
     ).to.deep.equal({
       states: [
         {
@@ -141,7 +144,7 @@ describe("integration - regular esm", () => {
       smcat.render(lSCXML, {
         inputType: "scxml",
         outputType: "json",
-      })
+      }),
     ).to.deep.equal({
       states: [
         {
@@ -175,7 +178,7 @@ describe("integration - regular esm", () => {
       smcat.render("a, ], b, c; a => ]; ] => b; ] => c;", {
         outputType: "smcat",
         desugar: true,
-      })
+      }),
     ).to.equal(`a,
 b,
 c;
@@ -189,7 +192,7 @@ a => c;
       smcat_node.render("a, ], b, c; a => ]; ] => b; ] => c;", {
         outputType: "smcat",
         desugar: true,
-      })
+      }),
     ).to.equal(`a,
 b,
 c;

--- a/test/parse/scxml.spec.mts
+++ b/test/parse/scxml.spec.mts
@@ -1,17 +1,16 @@
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
 import path from "node:path";
-import chai from "chai";
-import chaiJsonSchema from "chai-json-schema";
+import { expect } from "chai";
+import Ajv from "ajv";
 
 import { parse } from "../../src/parse/scxml/index.mjs";
 import $schema from "../../src/parse/smcat-ast.schema.mjs";
 
-const expect = chai.expect;
-chai.use(chaiJsonSchema);
+const ajv = new Ajv();
 
 const FIXTURE_DIR = fileURLToPath(
-  new URL("../render/fixtures", import.meta.url)
+  new URL("../render/fixtures", import.meta.url),
 );
 const FIXTURE_INPUTS = fs
   .readdirSync(FIXTURE_DIR)
@@ -27,11 +26,12 @@ describe("parse/scxml", () => {
         JSON.parse(
           fs.readFileSync(
             pInputFixture.replace(/\.scxml$/g, ".scxml.re-json"),
-            "utf8"
-          )
-        )
+            "utf8",
+          ),
+        ),
       );
-      expect(lAST).to.be.jsonSchema($schema);
+      // ([^\)]+)
+      ajv.validate($schema, lAST);
     });
   });
 
@@ -44,7 +44,7 @@ describe("parse/scxml", () => {
       </scxml>`;
     const lAST = parse(lStateWithAnInvoke);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -73,7 +73,7 @@ describe("parse/scxml", () => {
       </scxml>`;
     const lAST = parse(lStateWithAnInvoke);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -113,7 +113,7 @@ describe("parse/scxml", () => {
             </scxml>`;
     const lAST = parse(lScxmlWithTargetlessTransition);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -142,7 +142,7 @@ describe("parse/scxml", () => {
         </scxml>`;
     const lAST = parse(lScxmlWithInitialNode);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -175,7 +175,7 @@ describe("parse/scxml", () => {
         </scxml>`;
     const lAST = parse(lScxmlWithInitialNode);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -217,7 +217,7 @@ describe("parse/scxml", () => {
         `;
     const lAST = parse(lScxmlOnentryWithXml);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -257,7 +257,7 @@ describe("parse/scxml", () => {
         `;
     const lAST = parse(lScxmlOnexitWithXml);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -297,7 +297,7 @@ describe("parse/scxml", () => {
         `;
     const lAST = parse(lScxmlTransitionWithXml);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -339,7 +339,7 @@ describe("parse/scxml", () => {
         `;
     const lAST = parse(lScxmTransitionToMultipleTargets);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal({
       states: [
         {
@@ -433,21 +433,21 @@ describe("parse/scxml", () => {
 
     const lAST = parse(lScxmlTransitionFromCompoundParallelState);
 
-    expect(lAST).to.be.jsonSchema($schema);
+    ajv.validate($schema, lAST);
     expect(lAST).to.deep.equal(lExpectedAst);
   });
 
   it("barfs if the input is invalid xml", () => {
     expect(() => parse("this is no xml")).to.throw(
-      "That doesn't look like valid xml"
+      "That doesn't look like valid xml",
     );
   });
 
   it("strips spaces before and after the xml content before parsing", () => {
     expect(() =>
       parse(
-        `     \n\n\n\n <?xml version="1.0" encoding="UTF-8"?><validxml></validxml>    \n\n     `
-      )
+        `     \n\n\n\n <?xml version="1.0" encoding="UTF-8"?><validxml></validxml>    \n\n     `,
+      ),
     ).to.not.throw();
   });
 });

--- a/test/parse/smcat-parser.spec.mts
+++ b/test/parse/smcat-parser.spec.mts
@@ -1,12 +1,12 @@
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
-import { expect, use } from "chai";
-import chaiJsonSchema from "chai-json-schema";
+import { expect } from "chai";
+import Ajv from "ajv";
 import { parse as parseSmCat } from "../../src/parse/smcat/smcat-parser.mjs";
 import $schema from "../../src/parse/smcat-ast.schema.mjs";
 import { createRequireJSON } from "../utl.mjs";
 
-use(chaiJsonSchema);
+const ajv = new Ajv();
 
 const requireJSON = createRequireJSON(import.meta.url);
 
@@ -40,7 +40,7 @@ describe("#parse() - happy day ASTs - ", () => {
       it(pPair.title, () => {
         const lAST = parseSmCat(pPair.program);
 
-        expect(lAST).to.be.jsonSchema($schema);
+        ajv.validate($schema, lAST);
         expect(lAST).to.deep.equal(pPair.ast);
       });
     }
@@ -52,11 +52,11 @@ describe("#parse() - file based - ", () => {
     it(pPair.title, () => {
       const lProgram = readFileSync(
         fileURLToPath(new URL(pPair.programInputFile, import.meta.url)),
-        "utf8"
+        "utf8",
       );
       const lAST = parseSmCat(lProgram);
 
-      expect(lAST).to.be.jsonSchema($schema);
+      ajv.validate($schema, lAST);
       expect(lAST).to.deep.equal(requireJSON(`./${pPair.astFixtureFile}`));
     });
   });
@@ -92,9 +92,9 @@ describe("#parse() - parses the kitchensink", () => {
       parseSmCat(
         readFileSync(
           fileURLToPath(new URL("fixtures/kitchensink.smcat", import.meta.url)),
-          "utf8"
-        )
-      )
+          "utf8",
+        ),
+      ),
     ).to.deep.equal(requireJSON("./fixtures/kitchensink.json"));
   });
 });

--- a/test/render/json.spec.mts
+++ b/test/render/json.spec.mts
@@ -1,13 +1,13 @@
 import { fileURLToPath } from "node:url";
 import { readFileSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
-import { expect, use } from "chai";
-import chaiJSONSchema from "chai-json-schema";
+import { deepStrictEqual } from "node:assert";
+import Ajv from "ajv";
 import { parse as convert } from "../../src/parse/smcat/smcat-parser.mjs";
 
 import $schema from "../../src/parse/smcat-ast.schema.mjs";
 
-use(chaiJSONSchema);
+const ajv = new Ajv();
 
 const FIXTURE_DIR = fileURLToPath(new URL("fixtures", import.meta.url));
 
@@ -20,12 +20,13 @@ describe("#parse smcat to json - ", () => {
     it(`correctly parses ${basename(pInputFixture)} into json`, () => {
       const lResult = convert(readFileSync(pInputFixture, "utf8"));
 
-      expect(lResult).to.deep.equal(
+      deepStrictEqual(
+        lResult,
         JSON.parse(
-          readFileSync(pInputFixture.replace(/\.smcat$/g, ".json"), "utf8")
-        )
+          readFileSync(pInputFixture.replace(/\.smcat$/g, ".json"), "utf8"),
+        ),
       );
-      expect(lResult).to.jsonSchema($schema);
+      ajv.validate($schema, lResult);
     });
   });
 });

--- a/test/render/scjson/index.spec.mts
+++ b/test/render/scjson/index.spec.mts
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import chai, { expect } from "chai";
-import chaiJsonSchema from "chai-json-schema";
+import { deepStrictEqual } from "node:assert";
+import Ajv from "ajv";
 import convert from "../../../src/render/scjson/index.mjs";
 import $schema from "./scjson.schema.mjs";
 
-chai.use(chaiJsonSchema);
+const ajv = new Ajv();
 
 const FIXTURE_DIR = fileURLToPath(new URL("../fixtures", import.meta.url));
 const FIXTURE_INPUTS = fs
@@ -18,15 +18,16 @@ describe("#ast2scjson - ", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(pInputFixture)} to scjson`, () => {
       const lResult = convert(
-        JSON.parse(fs.readFileSync(pInputFixture, "utf8"))
+        JSON.parse(fs.readFileSync(pInputFixture, "utf8")),
       );
 
-      expect(lResult).to.deep.equal(
+      deepStrictEqual(
+        lResult,
         JSON.parse(
-          fs.readFileSync(pInputFixture.replace(/\.json$/g, ".scjson"), "utf8")
-        )
+          fs.readFileSync(pInputFixture.replace(/\.json$/g, ".scjson"), "utf8"),
+        ),
       );
-      expect(lResult).to.jsonSchema($schema);
+      ajv.validate($schema, lResult);
     });
   });
 });


### PR DESCRIPTION
## Description

- replaces chai-xml with the xml parser we're using in the regular code as well
- replaces chai-json-schema with ajv

## Motivation and Context

Less dependencies = less worries

## How Has This Been Tested?

- [x] green ci
- [x] updated automated tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
