### PR TITLE
refactor: replaces lodash functions where a good native alternative exists

### DIFF
--- a/dist/parse/scxml/index.mjs
+++ b/dist/parse/scxml/index.mjs
@@ -1,9 +1,9 @@
 import fastxml from "fast-xml-parser";
 import he from "he";
-import castArray from "lodash/castArray.js";
 import traverse from "traverse";
 import utl from "../../transform/utl.mjs";
 import parserHelpers from "../parser-helpers.mjs";
+import { castArray } from "./utl.mjs";
 import { normalizeMachine } from "./normalize-machine.mjs";
 const formatLabel = utl.formatLabel;
 function extractActions(pState, pActionType) {
@@ -99,7 +99,10 @@ function reduceTransition(pState) {
 function extractTransitions(pStates) {
     return pStates
         .filter((pState) => Object.prototype.hasOwnProperty.call(pState, "transition"))
-        .reduce((pAllTransitions, pThisState) => pAllTransitions.concat(castArray(pThisState.transition).reduce(reduceTransition(pThisState), [])), []);
+        .reduce((pAllTransitions, pThisState) => {
+        const lTransitionAsArray = castArray(pThisState.transition);
+        return pAllTransitions.concat(lTransitionAsArray.reduce(reduceTransition(pThisState), []));
+    }, []);
 }
 function mapMachine(pSCXMLStateMachine) {
     const lNormalizedMachine = normalizeMachine(pSCXMLStateMachine);

--- a/dist/parse/scxml/normalize-machine.mjs
+++ b/dist/parse/scxml/normalize-machine.mjs
@@ -1,4 +1,4 @@
-import castArray from "lodash/castArray.js";
+import { castArray } from "./utl.mjs";
 function normalizeInitialFromObject(pInitialObject, pId) {
     const lReturnValue = {
         id: pId ? `${pId}.initial` : "initial",

--- a/dist/parse/scxml/utl.mjs
+++ b/dist/parse/scxml/utl.mjs
@@ -1,0 +1,3 @@
+export function castArray(pAThing) {
+    return Array.isArray(pAThing) ? pAThing : [pAThing];
+}

--- a/dist/render/index-node.mjs
+++ b/dist/render/index-node.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import smcatRendererAsImported from "./smcat/index.mjs";
 import renderDot from "./dot/index.mjs";
 import vector from "./vector/vector-native-dot-with-fallback.mjs";
@@ -7,22 +6,20 @@ import scjson from "./scjson/index.mjs";
 import scxml from "./scxml/index.mjs";
 const smcat = smcatRendererAsImported;
 export default function getRenderFunction(pOutputType) {
-    const lOutputType2RenderFunction = {
-        smcat,
-        dot: renderDot,
-        svg: vector,
-        eps: vector,
-        ps: vector,
-        ps2: vector,
-        oldsvg: oldVector,
-        oldps2: oldVector,
-        oldeps: oldVector,
-        pdf: vector,
-        png: vector,
-        scjson,
-        scxml,
-    };
-    return has(lOutputType2RenderFunction, pOutputType)
-        ? lOutputType2RenderFunction[pOutputType]
-        : (pX) => pX;
+    const lOutputType2RenderFunctionMap = new Map([
+        ["smcat", smcat],
+        ["dot", renderDot],
+        ["svg", vector],
+        ["eps", vector],
+        ["ps", vector],
+        ["ps2", vector],
+        ["oldsvg", oldVector],
+        ["oldps2", oldVector],
+        ["oldeps", oldVector],
+        ["pdf", vector],
+        ["png", vector],
+        ["scjson", scjson],
+        ["scxml", scxml],
+    ]);
+    return lOutputType2RenderFunctionMap.get(pOutputType) ?? ((pX) => pX);
 }

--- a/dist/render/index.mjs
+++ b/dist/render/index.mjs
@@ -1,4 +1,3 @@
-import has from "lodash/has.js";
 import smcatRendererAsImported from "./smcat/index.mjs";
 import renderDot from "./dot/index.mjs";
 import svg from "./vector/vector-with-wasm.mjs";
@@ -6,15 +5,13 @@ import scjson from "./scjson/index.mjs";
 import scxml from "./scxml/index.mjs";
 const smcat = smcatRendererAsImported;
 export default function getRenderFunction(pOutputType) {
-    const lOutputType2RenderFunction = {
-        smcat,
-        dot: renderDot,
-        svg,
-        oldsvg: svg,
-        scjson,
-        scxml,
-    };
-    return has(lOutputType2RenderFunction, pOutputType)
-        ? lOutputType2RenderFunction[pOutputType]
-        : (pX) => pX;
+    const lOutputType2RenderFunctionMap = new Map([
+        ["smcat", smcat],
+        ["dot", renderDot],
+        ["svg", svg],
+        ["oldsvg", svg],
+        ["scjson", scjson],
+        ["scxml", scxml],
+    ]);
+    return lOutputType2RenderFunctionMap.get(pOutputType) ?? ((pX) => pX);
 }

--- a/dist/transform/desugar.mjs
+++ b/dist/transform/desugar.mjs
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep.js";
-import reject from "lodash/reject.js";
 import StateMachineModel from "../state-machine-model.mjs";
 import utl from "./utl.mjs";
 function fuseTransitionAttribute(pIncomingThing, pOutgoingThing, pJoinChar) {
@@ -52,10 +51,12 @@ function deSugarPseudoStates(pMachine, pPseudoStateNames, pOutgoingTransitionMap
 function removeStatesCascading(pMachine, pStateNames) {
     const lMachine = cloneDeep(pMachine);
     if (lMachine.transitions) {
-        lMachine.transitions = reject(lMachine.transitions, (pTransition) => pStateNames.some((pJunctionStateName) => pJunctionStateName === pTransition.from ||
+        lMachine.transitions = lMachine.transitions.filter((pTransition) => !pStateNames.some((pJunctionStateName) => pJunctionStateName === pTransition.from ||
             pJunctionStateName === pTransition.to));
     }
-    lMachine.states = reject(lMachine.states, (pState) => pStateNames.includes(pState.name)).map((pState) => pState.statemachine
+    lMachine.states = lMachine.states
+        .filter((pState) => !pStateNames.includes(pState.name))
+        .map((pState) => pState.statemachine
         ? {
             ...pState,
             statemachine: removeStatesCascading(pState.statemachine, pStateNames),

--- a/dist/utl.mjs
+++ b/dist/utl.mjs
@@ -1,0 +1,3 @@
+export function cloneDeep(pObject) {
+    return JSON.parse(JSON.stringify(pObject));
+}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "handlebars": "4.7.8",
     "he": "1.2.0",
     "indent-string": "5.0.0",
-    "lodash": "4.17.21",
     "semver": "^7.5.4",
     "traverse": "0.6.7",
     "wrap-ansi": "8.1.0"

--- a/src/parse/scxml/index.mjs
+++ b/src/parse/scxml/index.mjs
@@ -2,10 +2,10 @@
 /* eslint-disable security/detect-object-injection */
 import fastxml from "fast-xml-parser";
 import he from "he";
-import castArray from "lodash/castArray.js";
 import traverse from "traverse";
 import utl from "../../transform/utl.mjs";
 import parserHelpers from "../parser-helpers.mjs";
+import { castArray } from "./utl.mjs";
 import { normalizeMachine } from "./normalize-machine.mjs";
 
 const formatLabel = utl.formatLabel;
@@ -181,16 +181,12 @@ function extractTransitions(pStates) {
     .filter((pState) =>
       Object.prototype.hasOwnProperty.call(pState, "transition"),
     )
-    .reduce(
-      (pAllTransitions, pThisState) =>
-        pAllTransitions.concat(
-          castArray(pThisState.transition).reduce(
-            reduceTransition(pThisState),
-            [],
-          ),
-        ),
-      [],
-    );
+    .reduce((pAllTransitions, pThisState) => {
+      const lTransitionAsArray = castArray(pThisState.transition);
+      return pAllTransitions.concat(
+        lTransitionAsArray.reduce(reduceTransition(pThisState), []),
+      );
+    }, []);
 }
 
 /**

--- a/src/parse/scxml/normalize-machine.mts
+++ b/src/parse/scxml/normalize-machine.mts
@@ -1,4 +1,4 @@
-import castArray from "lodash/castArray.js";
+import { castArray } from "./utl.mjs";
 import type { INormalizedSCXMLMachine, ISCXMLInitialState } from "./scxml.js";
 
 function normalizeInitialFromObject(

--- a/src/parse/scxml/utl.mts
+++ b/src/parse/scxml/utl.mts
@@ -1,0 +1,3 @@
+export function castArray(pAThing: unknown): Array<unknown> {
+  return Array.isArray(pAThing) ? pAThing : [pAThing];
+}

--- a/src/render/dot/index.mjs
+++ b/src/render/dot/index.mjs
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash/cloneDeep.js";
+import { cloneDeep } from "../../utl.mjs";
 import options from "../../options.mjs";
 import StateMachineModel from "../../state-machine-model.mjs";
 import attributebuilder from "./attributebuilder.mjs";

--- a/src/render/dot/state-transformers.mts
+++ b/src/render/dot/state-transformers.mts
@@ -1,5 +1,5 @@
-import cloneDeep from "lodash/cloneDeep.js";
 import type { IState } from "types/state-machine-cat.js";
+import { cloneDeep } from "../../utl.mjs";
 import type { IExtendedState } from "./extended-types.js";
 import utl from "./utl.mjs";
 

--- a/src/render/index-node.mts
+++ b/src/render/index-node.mts
@@ -1,5 +1,3 @@
-/* eslint-disable security/detect-object-injection */
-import has from "lodash/has.js";
 import type {
   OutputType,
   RenderFunctionType,
@@ -19,25 +17,23 @@ const smcat = smcatRendererAsImported as StringRenderFunctionType;
 export default function getRenderFunction(
   pOutputType: OutputType,
 ): RenderFunctionType {
-  const lOutputType2RenderFunction: {
-    [outputType: string]: RenderFunctionType;
-  } = {
-    smcat,
-    dot: renderDot,
-    svg: vector,
-    eps: vector,
-    ps: vector,
-    ps2: vector,
-    oldsvg: oldVector,
-    oldps2: oldVector,
-    oldeps: oldVector,
-    pdf: vector,
-    png: vector,
-    scjson,
-    scxml,
-  };
+  const lOutputType2RenderFunctionMap: Map<string, RenderFunctionType> =
+    // @ts-expect-error - something something some of these things tsc doesn't recognize as RenderFunctionType
+    new Map([
+      ["smcat", smcat],
+      ["dot", renderDot],
+      ["svg", vector],
+      ["eps", vector],
+      ["ps", vector],
+      ["ps2", vector],
+      ["oldsvg", oldVector],
+      ["oldps2", oldVector],
+      ["oldeps", oldVector],
+      ["pdf", vector],
+      ["png", vector],
+      ["scjson", scjson],
+      ["scxml", scxml],
+    ]);
 
-  return has(lOutputType2RenderFunction, pOutputType)
-    ? lOutputType2RenderFunction[pOutputType]
-    : (pX) => pX;
+  return lOutputType2RenderFunctionMap.get(pOutputType) ?? ((pX) => pX);
 }

--- a/src/render/index.mts
+++ b/src/render/index.mts
@@ -1,5 +1,3 @@
-/* eslint-disable security/detect-object-injection */
-import has from "lodash/has.js";
 import type {
   OutputType,
   RenderFunctionType,
@@ -18,18 +16,16 @@ const smcat = smcatRendererAsImported as StringRenderFunctionType;
 export default function getRenderFunction(
   pOutputType: OutputType,
 ): RenderFunctionType {
-  const lOutputType2RenderFunction: {
-    [outputType: string]: RenderFunctionType;
-  } = {
-    smcat,
-    dot: renderDot,
-    svg,
-    oldsvg: svg,
-    scjson,
-    scxml,
-  };
+  const lOutputType2RenderFunctionMap: Map<string, RenderFunctionType> =
+    // @ts-expect-error - something something some of these things tsc doesn't recognize as RenderFunctionType
+    new Map([
+      ["smcat", smcat],
+      ["dot", renderDot],
+      ["svg", svg],
+      ["oldsvg", svg],
+      ["scjson", scjson],
+      ["scxml", scxml],
+    ]);
 
-  return has(lOutputType2RenderFunction, pOutputType)
-    ? lOutputType2RenderFunction[pOutputType]
-    : (pX) => pX;
+  return lOutputType2RenderFunctionMap.get(pOutputType) ?? ((pX) => pX);
 }

--- a/src/render/smcat/index.mts
+++ b/src/render/smcat/index.mts
@@ -1,7 +1,7 @@
 // @ts-expect-error the type definitions for Handlebars don't match what we're
 // actually using
 import Handlebars from "handlebars/dist/handlebars.runtime.js";
-import cloneDeep from "lodash/cloneDeep.js";
+import { cloneDeep } from "../../utl.mjs";
 import type {
   IState,
   IStateMachine,

--- a/src/transform/desugar.mts
+++ b/src/transform/desugar.mts
@@ -1,6 +1,5 @@
 /* eslint-disable security/detect-object-injection */
 import cloneDeep from "lodash/cloneDeep.js";
-import reject from "lodash/reject.js";
 import type {
   IStateMachine,
   ITransition,
@@ -133,25 +132,29 @@ function removeStatesCascading(
   const lMachine = cloneDeep(pMachine);
 
   if (lMachine.transitions) {
-    lMachine.transitions = reject(lMachine.transitions, (pTransition) =>
-      pStateNames.some(
-        (pJunctionStateName) =>
-          pJunctionStateName === pTransition.from ||
-          pJunctionStateName === pTransition.to,
-      ),
+    lMachine.transitions = lMachine.transitions.filter(
+      (pTransition) =>
+        !pStateNames.some(
+          (pJunctionStateName) =>
+            pJunctionStateName === pTransition.from ||
+            pJunctionStateName === pTransition.to,
+        ),
     );
   }
 
-  lMachine.states = reject(lMachine.states, (pState) =>
-    pStateNames.includes(pState.name),
-  ).map((pState) =>
-    pState.statemachine
-      ? {
-          ...pState,
-          statemachine: removeStatesCascading(pState.statemachine, pStateNames),
-        }
-      : pState,
-  );
+  lMachine.states = lMachine.states
+    .filter((pState) => !pStateNames.includes(pState.name))
+    .map((pState) =>
+      pState.statemachine
+        ? {
+            ...pState,
+            statemachine: removeStatesCascading(
+              pState.statemachine,
+              pStateNames,
+            ),
+          }
+        : pState,
+    );
   return lMachine;
 }
 

--- a/src/transform/desugar.mts
+++ b/src/transform/desugar.mts
@@ -1,10 +1,10 @@
 /* eslint-disable security/detect-object-injection */
-import cloneDeep from "lodash/cloneDeep.js";
 import type {
   IStateMachine,
   ITransition,
   StateType,
 } from "types/state-machine-cat.js";
+import { cloneDeep } from "../utl.mjs";
 import StateMachineModel from "../state-machine-model.mjs";
 import utl from "./utl.mjs";
 

--- a/src/utl.mts
+++ b/src/utl.mts
@@ -1,0 +1,5 @@
+export function cloneDeep<AnyType>(pObject: AnyType): AnyType {
+  // when we drop node 16 we can use [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
+  // in stead of this hack
+  return JSON.parse(JSON.stringify(pObject));
+}


### PR DESCRIPTION
## Description

- replaces instances of castArray, reject and has with (just as straightforward) native variants
- replaces cloneDeep with the json hack. When nodejs 16 stops being supported we can switch it to structuredClone.

## Motivation and Context

less dependencies === less pain

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
