### PR TITLE
refactor: removes chalk, indent-string and wrap-ansi

### DIFF
--- a/dist/render/dot/index.mjs
+++ b/dist/render/dot/index.mjs
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash/cloneDeep.js";
+import { cloneDeep } from "../../utl.mjs";
 import options from "../../options.mjs";
 import StateMachineModel from "../../state-machine-model.mjs";
 import attributebuilder from "./attributebuilder.mjs";

--- a/dist/render/dot/state-transformers.mjs
+++ b/dist/render/dot/state-transformers.mjs
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash/cloneDeep.js";
+import { cloneDeep } from "../../utl.mjs";
 import utl from "./utl.mjs";
 function isType(pString) {
     return (pState) => pState.type === pString;

--- a/dist/render/smcat/index.mjs
+++ b/dist/render/smcat/index.mjs
@@ -1,5 +1,5 @@
 import Handlebars from "handlebars/dist/handlebars.runtime.js";
-import cloneDeep from "lodash/cloneDeep.js";
+import { cloneDeep } from "../../utl.mjs";
 await import("./smcat.template.js");
 const NAME_QUOTABLE = /;|,|{| |\[/;
 const ACTIONS_QUOTABLE = /;|,|{/;

--- a/dist/render/vector/vector-native-dot-with-fallback.mjs
+++ b/dist/render/vector/vector-native-dot-with-fallback.mjs
@@ -1,12 +1,7 @@
 import { Graphviz } from "@hpcc-js/wasm/graphviz";
-import indentString from "indent-string";
-import wrapAnsi from "wrap-ansi";
-import chalk from "chalk";
 import options from "../../options.mjs";
 import ast2dot from "../dot/index.mjs";
 import dotToVectorNative from "./dot-to-vector-native.mjs";
-const DEFAULT_INDENT = 2;
-const DOGMATIC_CONSOLE_WIDTH = 78;
 const VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS = ["pdf", "png"];
 const gGraphViz = await Graphviz.load();
 const renderVector = (pStateMachine, pOptions) => {
@@ -27,7 +22,7 @@ const renderVector = (pStateMachine, pOptions) => {
                 "both formats.\n");
         }
         if (!pOptions?.noDotNativeWarning)
-            process.stderr.write(indentString(wrapAnsi(`\n${chalk.yellow("warning:")} GraphViz 'dot' executable not found. Falling back to wasm.\n\n`, DOGMATIC_CONSOLE_WIDTH), DEFAULT_INDENT));
+            process.stderr.write(`  warning: GraphViz 'dot' executable not found. Falling back to wasm.\n\n`);
         return gGraphViz.layout(lDotProgram, lDotOptions.format, lDotOptions.engine);
     }
 };

--- a/dist/transform/desugar.mjs
+++ b/dist/transform/desugar.mjs
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash/cloneDeep.js";
+import { cloneDeep } from "../utl.mjs";
 import StateMachineModel from "../state-machine-model.mjs";
 import utl from "./utl.mjs";
 function fuseTransitionAttribute(pIncomingThing, pOutgoingThing, pJoinChar) {

--- a/package.json
+++ b/package.json
@@ -92,15 +92,12 @@
   "dependencies": {
     "@hpcc-js/wasm": "2.13.1",
     "ajv": "8.12.0",
-    "chalk": "5.3.0",
     "commander": "11.0.0",
     "fast-xml-parser": "4.2.7",
     "handlebars": "4.7.8",
     "he": "1.2.0",
-    "indent-string": "5.0.0",
     "semver": "^7.5.4",
-    "traverse": "0.6.7",
-    "wrap-ansi": "8.1.0"
+    "traverse": "0.6.7"
   },
   "devDependencies": {
     "@types/chai": "4.3.5",

--- a/src/render/vector/vector-native-dot-with-fallback.mts
+++ b/src/render/vector/vector-native-dot-with-fallback.mts
@@ -1,7 +1,4 @@
 import { type Engine, type Format, Graphviz } from "@hpcc-js/wasm/graphviz";
-import indentString from "indent-string";
-import wrapAnsi from "wrap-ansi";
-import chalk from "chalk";
 import {
   IRenderOptions,
   OutputType,
@@ -13,8 +10,6 @@ import dotToVectorNative, {
   DotToVectorNativeOptionsType,
 } from "./dot-to-vector-native.mjs";
 
-const DEFAULT_INDENT = 2;
-const DOGMATIC_CONSOLE_WIDTH = 78;
 const VIZ_JS_UNSUPPORTED_OUTPUT_FORMATS: string[] = ["pdf", "png"];
 const gGraphViz = await Graphviz.load();
 
@@ -46,15 +41,7 @@ const renderVector: StringRenderFunctionType = (pStateMachine, pOptions) => {
 
     if (!pOptions?.noDotNativeWarning)
       process.stderr.write(
-        indentString(
-          wrapAnsi(
-            `\n${chalk.yellow(
-              "warning:",
-            )} GraphViz 'dot' executable not found. Falling back to wasm.\n\n`,
-            DOGMATIC_CONSOLE_WIDTH,
-          ),
-          DEFAULT_INDENT,
-        ),
+        `  warning: GraphViz 'dot' executable not found. Falling back to wasm.\n\n`,
       );
 
     return gGraphViz.layout(


### PR DESCRIPTION
## Description

- removes chalk, indent-string and wrap-ansi

## Motivation and Context

- less dependencies === less worries
- the combined use of these three packages for one (exceptional) case and to format one line of text smaller than 60 characters was massive overkill.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
