### PR TITLE
refactor: replaces chai with node:assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,14 +100,11 @@
     "traverse": "0.6.7"
   },
   "devDependencies": {
-    "@types/chai": "4.3.5",
     "@types/he": "1.2.0",
-    "@types/lodash": "4.14.196",
     "@types/mocha": "10.0.1",
     "@typescript-eslint/eslint-plugin": "6.2.1",
     "@typescript-eslint/parser": "6.2.1",
     "c8": "8.0.1",
-    "chai": "4.3.7",
     "dependency-cruiser": "13.1.1",
     "esbuild": "0.18.17",
     "eslint": "8.46.0",

--- a/test/bin.spec.mts
+++ b/test/bin.spec.mts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { strictEqual } from "node:assert";
 
-describe("e2e", () => {
+describe("e2e [a]", () => {
   it("by default renders an svg from an smcat program", () => {
     const { status, stdout } = spawnSync("node", [
       "bin/smcat.mjs",

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import * as actions from "../../src/cli/actions.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -72,19 +72,19 @@ function resetOutputDirectory() {
   });
 }
 
-describe("#cli - actions", () => {
+describe("#cli - actions [a]", () => {
   before("set up", resetOutputDirectory);
 
   after("tear down", resetOutputDirectory);
 
-  describe("#transform()", () => {
+  describe("#transform() [a]", () => {
     testPairs.forEach((pPair) => {
       it(pPair.title, (pDone) => {
         actions
           .transform(pPair.input.options)
           .then((pResult) => {
             /* eslint no-unused-expressions:0 */
-            expect(pResult).to.be.true;
+            strictEqual(pResult, true);
 
             // TE DOEN: understand why this fails
             // const lFound = fs.readFileSync(pPair.input.options.outputTo, "utf8");
@@ -102,11 +102,9 @@ describe("#cli - actions", () => {
     });
   });
 
-  describe("formatError()", () => {
+  describe("formatError() [a]", () => {
     it("returns the message of non-syntax errors", () => {
-      expect(actions.formatError(new Error("hatsikidee!"))).to.equal(
-        "hatsikidee!",
-      );
+      strictEqual(actions.formatError(new Error("hatsikidee!")), "hatsikidee!");
     });
 
     it("returns man and horse of syntax errors", () => {
@@ -119,7 +117,8 @@ describe("#cli - actions", () => {
         },
       };
 
-      expect(actions.formatError(lError)).to.equal(
+      strictEqual(
+        actions.formatError(lError),
         `\n  syntax error on line 481, column 69:\n  Make my day!\n\n`,
       );
     });

--- a/test/cli/attributes-parser.spec.mts
+++ b/test/cli/attributes-parser.spec.mts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { parse } from "../../src/cli/attributes-parser.mjs";
 
 function assertSyntaxError(pProgram, pParseFunction, pErrorType) {
@@ -11,9 +11,9 @@ function assertSyntaxError(pProgram, pParseFunction, pErrorType) {
     if (pParseFunction(pProgram)) {
       lStillRan = true;
     }
-    expect(lStillRan).to.equal(false);
+    strictEqual(lStillRan, false);
   } catch (pError) {
-    expect(pError.name).to.equal(pErrorType);
+    strictEqual(pError.name, pErrorType);
   }
 }
 /*
@@ -22,40 +22,36 @@ Branches     : 65.46% ( 1696/2591 )
 Functions    : 92.61% ( 376/406 )
 Lines        : 90.43% ( 2391/2644 )
 */
-describe("#cli - properties-parse", () => {
+describe("#cli - properties-parse [a]", () => {
   describe("happy day - one param", () => {
     it("one string param", () => {
-      expect(parse('stringu="a string"')).to.deep.equal([
+      deepStrictEqual(parse('stringu="a string"'), [
         { name: "stringu", value: "a string" },
       ]);
     });
     it("one unquoted string param", () => {
-      expect(parse("stringu=another_string")).to.deep.equal([
+      deepStrictEqual(parse("stringu=another_string"), [
         { name: "stringu", value: "another_string" },
       ]);
     });
     it("one boolean param", () => {
-      expect(parse("booleaneu=false")).to.deep.equal([
+      deepStrictEqual(parse("booleaneu=false"), [
         { name: "booleaneu", value: false },
       ]);
     });
     it("one boolean param (true)", () => {
-      expect(parse("booleaneu=true")).to.deep.equal([
+      deepStrictEqual(parse("booleaneu=true"), [
         { name: "booleaneu", value: true },
       ]);
     });
     it("one integer param", () => {
-      expect(parse("interu=481")).to.deep.equal([
-        { name: "interu", value: 481 },
-      ]);
+      deepStrictEqual(parse("interu=481"), [{ name: "interu", value: 481 }]);
     });
     it("one float param", () => {
-      expect(parse("floatu=3.14")).to.deep.equal([
-        { name: "floatu", value: 3.14 },
-      ]);
+      deepStrictEqual(parse("floatu=3.14"), [{ name: "floatu", value: 3.14 }]);
     });
     it("one param embedded in spacy stuff", () => {
-      expect(parse(" spaces \t=\r\n    false ")).to.deep.equal([
+      deepStrictEqual(parse(" spaces \t=\r\n    false "), [
         { name: "spaces", value: false },
       ]);
     });
@@ -63,14 +59,14 @@ describe("#cli - properties-parse", () => {
 
   describe("happy day - multiple params", () => {
     it("two string params", () => {
-      expect(parse(' stringu= "a string " stringb = string')).to.deep.equal([
+      deepStrictEqual(parse(' stringu= "a string " stringb = string'), [
         { name: "stringu", value: "a string " },
         { name: "stringb", value: "string" },
       ]);
     });
   });
 
-  describe("alternates", () => {
+  describe("alternates [a]", () => {
     it("empty string", () => {
       assertSyntaxError("", parse);
     });

--- a/test/cli/execute-command-line.spec.mts
+++ b/test/cli/execute-command-line.spec.mts
@@ -23,7 +23,7 @@ class WritableTestStream extends Writable {
   }
 }
 
-describe("#cli - execute-command-line", () => {
+describe("#cli - execute-command-line [a]", () => {
   it("--license displays the license on stdout", async () => {
     const lOutStream = new WritableTestStream([
       /The MIT License \(MIT\)/,

--- a/test/cli/file-name-to-stream.spec.mts
+++ b/test/cli/file-name-to-stream.spec.mts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { ReadStream, WriteStream, unlinkSync } from "node:fs";
 import { Readable, Writable } from "node:stream";
-import { expect } from "chai";
+import { notStrictEqual, strictEqual } from "node:assert";
 import {
   getInStream,
   getOutStream,
@@ -18,9 +18,9 @@ const removeDammit = (pFileName) => {
   }
 };
 
-describe("fileNameToStream", () => {
+describe("fileNameToStream [a]", () => {
   const OUTFILE = fileURLToPath(
-    new URL("output/tmp_hello_filename_to_stream.json", import.meta.url)
+    new URL("output/tmp_hello_filename_to_stream.json", import.meta.url),
   );
 
   after("tear down", () => {
@@ -28,41 +28,41 @@ describe("fileNameToStream", () => {
   });
 
   it("getOutStream('-') is a writable stream", () => {
-    expect(getOutStream("-") instanceof Writable).to.be.true;
+    strictEqual(getOutStream("-") instanceof Writable, true);
   });
   it("getOutStream('-') yields stdout", () => {
-    expect(getOutStream("-")).to.equal(process.stdout);
+    strictEqual(getOutStream("-"), process.stdout);
   });
   it("getOutStream('-') yields does not yield a file stream", () => {
-    expect(getOutStream("-") instanceof WriteStream).to.be.false;
+    strictEqual(getOutStream("-") instanceof WriteStream, false);
   });
   it("getOutStream(OUTFILE) yields a writable", () => {
-    expect(getOutStream(OUTFILE) instanceof Writable).to.be.true;
+    strictEqual(getOutStream(OUTFILE) instanceof Writable, true);
   });
   it("getOutStream(OUTFILE) yields a writable stream", () => {
-    expect(getOutStream(OUTFILE) instanceof WriteStream).to.be.true;
+    strictEqual(getOutStream(OUTFILE) instanceof WriteStream, true);
   });
   it("getOutStream(OUTFILE) does not yield stdout", () => {
-    expect(getOutStream(OUTFILE)).to.not.equal(process.stdout);
+    notStrictEqual(getOutStream(OUTFILE), process.stdout);
   });
 
   it("getInStream('-') is a readable stream", () => {
-    expect(getInStream("-") instanceof Readable).to.be.true;
+    strictEqual(getInStream("-") instanceof Readable, true);
   });
   it("getInStream('-') yields stdin", () => {
-    expect(getInStream("-")).to.equal(process.stdin);
+    strictEqual(getInStream("-"), process.stdin);
   });
   it("getInStream('-') does not yield a file stream", () => {
-    expect(getInStream("-") instanceof ReadStream).to.be.false;
+    strictEqual(getInStream("-") instanceof ReadStream, false);
   });
   it("getInStream(OUTFILE) yields a writable stream", () => {
-    expect(getInStream(OUTFILE) instanceof Readable).to.be.true;
+    strictEqual(getInStream(OUTFILE) instanceof Readable, true);
   });
   it("getInStream(OUTFILE) yields a readable file stream", () => {
-    expect(getInStream(OUTFILE) instanceof ReadStream).to.be.true;
+    strictEqual(getInStream(OUTFILE) instanceof ReadStream, true);
   });
   it("getInStream(OUTFILE) does not yields stdin", () => {
-    expect(getInStream(OUTFILE)).to.not.equal(process.stdin);
+    notStrictEqual(getInStream(OUTFILE), process.stdin);
   });
 });
 

--- a/test/cli/normalize.spec.mts
+++ b/test/cli/normalize.spec.mts
@@ -1,9 +1,9 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import normalize from "../../src/cli/normalize.mjs";
 
-describe("#cli - normalize", () => {
+describe("#cli - normalize [a]", () => {
   it("doesn't really know when presented with nothing", () => {
-    expect(normalize(null, {})).to.deep.equal({
+    deepStrictEqual(normalize(null, {}), {
       inputFrom: "-",
       inputType: "smcat",
       outputTo: "-",
@@ -18,7 +18,7 @@ describe("#cli - normalize", () => {
   });
 
   it("generates defaults when presented with only standard input", () => {
-    expect(normalize("-", { outputTo: "-" })).to.deep.equal({
+    deepStrictEqual(normalize("-", { outputTo: "-" }), {
       inputFrom: "-",
       inputType: "smcat",
       outputTo: "-",
@@ -33,7 +33,7 @@ describe("#cli - normalize", () => {
   });
 
   it("generates defaults when presented with only an (unclassifyable) input", () => {
-    expect(normalize("loopvogel", {})).to.deep.equal({
+    deepStrictEqual(normalize("loopvogel", {}), {
       inputFrom: "loopvogel",
       inputType: "smcat",
       outputTo: "loopvogel.svg",
@@ -48,7 +48,7 @@ describe("#cli - normalize", () => {
   });
 
   it("generates defaults when presented with only a (classifyable) input", () => {
-    expect(normalize("loopvogel.smcat", {})).to.deep.equal({
+    deepStrictEqual(normalize("loopvogel.smcat", {}), {
       inputFrom: "loopvogel.smcat",
       inputType: "smcat",
       outputTo: "loopvogel.svg",
@@ -63,7 +63,7 @@ describe("#cli - normalize", () => {
   });
 
   it("generates defaults when presented with only a (classifyable; json) input", () => {
-    expect(normalize("loopvogel.json", {})).to.deep.equal({
+    deepStrictEqual(normalize("loopvogel.json", {}), {
       inputFrom: "loopvogel.json",
       inputType: "json",
       outputTo: "loopvogel.svg",
@@ -78,33 +78,11 @@ describe("#cli - normalize", () => {
   });
 
   it("generates defaults when presented with only a hard input type (json)", () => {
-    expect(normalize("loopvogel.djeezon", { inputType: "json" })).to.deep.equal(
-      {
-        inputFrom: "loopvogel.djeezon",
-        inputType: "json",
-        outputTo: "loopvogel.svg",
-        outputType: "svg",
-        engine: "dot",
-        direction: "top-down",
-        dotGraphAttrs: [],
-        dotNodeAttrs: [],
-        dotEdgeAttrs: [],
-        desugar: false,
-      }
-    );
-  });
-
-  it("respects parameters - even when they're a bit weird", () => {
-    expect(
-      normalize("loopvogel.smcat", {
-        outputTo: "somethingElse.dot",
-        outputType: "json",
-      })
-    ).to.deep.equal({
-      inputFrom: "loopvogel.smcat",
-      inputType: "smcat",
-      outputTo: "somethingElse.dot",
-      outputType: "json",
+    deepStrictEqual(normalize("loopvogel.djeezon", { inputType: "json" }), {
+      inputFrom: "loopvogel.djeezon",
+      inputType: "json",
+      outputTo: "loopvogel.svg",
+      outputType: "svg",
       engine: "dot",
       direction: "top-down",
       dotGraphAttrs: [],
@@ -114,8 +92,29 @@ describe("#cli - normalize", () => {
     });
   });
 
+  it("respects parameters - even when they're a bit weird", () => {
+    deepStrictEqual(
+      normalize("loopvogel.smcat", {
+        outputTo: "somethingElse.dot",
+        outputType: "json",
+      }),
+      {
+        inputFrom: "loopvogel.smcat",
+        inputType: "smcat",
+        outputTo: "somethingElse.dot",
+        outputType: "json",
+        engine: "dot",
+        direction: "top-down",
+        dotGraphAttrs: [],
+        dotNodeAttrs: [],
+        dotEdgeAttrs: [],
+        desugar: false,
+      },
+    );
+  });
+
   it("respects parameters - even when they're a bit sparse", () => {
-    expect(normalize("-", {})).to.deep.equal({
+    deepStrictEqual(normalize("-", {}), {
       inputFrom: "-",
       inputType: "smcat",
       outputTo: "-",
@@ -130,7 +129,7 @@ describe("#cli - normalize", () => {
   });
 
   it("accepts and processes the 'engine' parameter", () => {
-    expect(normalize("eidereend.wak", { engine: "neato" })).to.deep.equal({
+    deepStrictEqual(normalize("eidereend.wak", { engine: "neato" }), {
       inputFrom: "eidereend.wak",
       inputType: "smcat",
       outputTo: "eidereend.svg",
@@ -145,9 +144,7 @@ describe("#cli - normalize", () => {
   });
 
   it("accepts and processes the 'direction' parameter", () => {
-    expect(
-      normalize("eidereend.wak", { direction: "left-right" })
-    ).to.deep.equal({
+    deepStrictEqual(normalize("eidereend.wak", { direction: "left-right" }), {
       inputFrom: "eidereend.wak",
       inputType: "smcat",
       outputTo: "eidereend.svg",
@@ -162,33 +159,34 @@ describe("#cli - normalize", () => {
   });
 
   it("accepts and processes the 'dotGraphAttrs' parameter", () => {
-    expect(
-      normalize("eidereend.wak", { dotGraphAttrs: "mies=zus wim=jet" })
-    ).to.deep.equal({
-      inputFrom: "eidereend.wak",
-      inputType: "smcat",
-      outputTo: "eidereend.svg",
-      outputType: "svg",
-      engine: "dot",
-      direction: "top-down",
-      dotGraphAttrs: [
-        {
-          name: "mies",
-          value: "zus",
-        },
-        {
-          name: "wim",
-          value: "jet",
-        },
-      ],
-      dotNodeAttrs: [],
-      dotEdgeAttrs: [],
-      desugar: false,
-    });
+    deepStrictEqual(
+      normalize("eidereend.wak", { dotGraphAttrs: "mies=zus wim=jet" }),
+      {
+        inputFrom: "eidereend.wak",
+        inputType: "smcat",
+        outputTo: "eidereend.svg",
+        outputType: "svg",
+        engine: "dot",
+        direction: "top-down",
+        dotGraphAttrs: [
+          {
+            name: "mies",
+            value: "zus",
+          },
+          {
+            name: "wim",
+            value: "jet",
+          },
+        ],
+        dotNodeAttrs: [],
+        dotEdgeAttrs: [],
+        desugar: false,
+      },
+    );
   });
 
   it("classifies the .scxml extension as scxml", () => {
-    expect(normalize("model.scxml")).to.deep.equal({
+    deepStrictEqual(normalize("model.scxml"), {
       inputFrom: "model.scxml",
       inputType: "scxml",
       outputTo: "model.svg",
@@ -203,7 +201,7 @@ describe("#cli - normalize", () => {
   });
 
   it("classifies the .xml extension as scxml", () => {
-    expect(normalize("model.xml")).to.deep.equal({
+    deepStrictEqual(normalize("model.xml"), {
       inputFrom: "model.xml",
       inputType: "scxml",
       outputTo: "model.svg",
@@ -218,7 +216,7 @@ describe("#cli - normalize", () => {
   });
 
   it("appends .svg for outputType oldsvg", () => {
-    expect(normalize("model.smcat", { outputType: "oldsvg" })).to.deep.equal({
+    deepStrictEqual(normalize("model.smcat", { outputType: "oldsvg" }), {
       inputFrom: "model.smcat",
       inputType: "smcat",
       outputTo: "model.svg",
@@ -233,7 +231,7 @@ describe("#cli - normalize", () => {
   });
 
   it("handles unspecified everything", () => {
-    expect(normalize()).to.deep.equal({
+    deepStrictEqual(normalize(), {
       inputFrom: "-",
       inputType: "smcat",
       outputTo: "-",

--- a/test/cli/validations.spec.mts
+++ b/test/cli/validations.spec.mts
@@ -1,10 +1,10 @@
-import { expect } from "chai";
+import { doesNotThrow, strictEqual, throws } from "node:assert";
 import validations from "../../src/cli/validations.mjs";
 
 describe("#cli - validate", () => {
   describe("output type", () => {
     it("OK's on a valid output type", () => {
-      expect(validations.validOutputType("json")).to.equal("json");
+      strictEqual(validations.validOutputType("json"), "json");
     });
     it("'notavalidOutputType' is not a valid output type", () => {
       let lFoundError = "";
@@ -14,15 +14,18 @@ describe("#cli - validate", () => {
       } catch (pError) {
         lFoundError = pError.message;
       }
-      expect(lFoundError).to.contain(
-        "error: 'notavalidOutputType' is not a valid output type."
+      strictEqual(
+        lFoundError.includes(
+          "error: 'notavalidOutputType' is not a valid output type.",
+        ),
+        true,
       );
     });
   });
 
   describe("#validInputType() - ", () => {
     it("'smcat' is a valid type", () => {
-      expect(validations.validInputType("smcat")).to.equal("smcat");
+      strictEqual(validations.validInputType("smcat"), "smcat");
     });
 
     it("'notAValidInputType' is not a valid input type", () => {
@@ -33,15 +36,18 @@ describe("#cli - validate", () => {
       } catch (pError) {
         lFoundError = pError.message;
       }
-      expect(lFoundError).to.contain(
-        "error: 'notAValidInputType' is not a valid input type"
+      strictEqual(
+        lFoundError.includes(
+          "error: 'notAValidInputType' is not a valid input type",
+        ),
+        true,
       );
     });
   });
 
   describe("#validEngine() - ", () => {
     it("'circo' is a valid type", () => {
-      expect(validations.validEngine("circo")).to.equal("circo");
+      strictEqual(validations.validEngine("circo"), "circo");
     });
 
     it("'Ford diesel engine' is not a valid engine", () => {
@@ -52,15 +58,13 @@ describe("#cli - validate", () => {
       } catch (pError) {
         lFoundError = pError.message;
       }
-      expect(lFoundError).to.contain(
-        "error: 'Ford diesel engine' is not a valid input type"
-      );
+      strictEqual(lFoundError.includes("is not a valid input type"), true);
     });
   });
 
   describe("#validDirection() - ", () => {
     it("'left-right' is a valid type", () => {
-      expect(validations.validDirection("left-right")).to.equal("left-right");
+      strictEqual(validations.validDirection("left-right"), "left-right");
     });
 
     it("'to-the-moon-and-back' is not a valid type", () => {
@@ -71,15 +75,18 @@ describe("#cli - validate", () => {
       } catch (pError) {
         lFoundError = pError.message;
       }
-      expect(lFoundError).to.contain(
-        "error: 'to-the-moon-and-back' is not a valid direction"
+      strictEqual(
+        lFoundError.includes(
+          "error: 'to-the-moon-and-back' is not a valid direction",
+        ),
+        true,
       );
     });
   });
 
   describe("#validDotAttrs() - ", () => {
     it("'aap=noot' is a valid dot attribute", () => {
-      expect(validations.validDotAttrs("aap=noot")).to.equal("aap=noot");
+      strictEqual(validations.validDotAttrs("aap=noot"), "aap=noot");
     });
 
     it("aap is not a valid dot attribute", () => {
@@ -90,8 +97,11 @@ describe("#cli - validate", () => {
       } catch (pError) {
         lFoundError = pError.message;
       }
-      expect(lFoundError).to.contain(
-        'Invalid dot attributes: Expected name value pair but "a" found.'
+      strictEqual(
+        lFoundError.includes(
+          'Invalid dot attributes: Expected name value pair but "a" found.',
+        ),
+        true,
       );
     });
   });
@@ -102,52 +112,62 @@ describe("#cli - validate", () => {
         validations.validateArguments({
           inputFrom: new URL(
             "../parse/fixtures/comment-00-single-after-state.smcat",
-            import.meta.url
+            import.meta.url,
           ),
           outputTo: "kaboeki.dot",
           outputType: "dot",
         });
-        expect("still here").to.equal("still here");
+        strictEqual("still here", "still here");
       } catch (pError) {
-        expect(pError.message).to.equal("should not be an exception");
+        strictEqual(pError.message, "should not be an exception");
       }
     });
 
     it("'-T smcat -o - -' is oki", () => {
-      expect(() => {
+      doesNotThrow(() => {
         validations.validateArguments({
           inputFrom: "-",
           outputTo: "-",
           outputType: "smcat",
         });
-      }).to.not.throw();
+      });
     });
 
     it("'-T ast -o - input-doesnot-exists' complains about non existing file", () => {
-      expect(() => {
-        validations.validateArguments({
-          inputFrom: "input-doesnot-exist",
-          outputTo: "-",
-          outputType: "ast",
-        });
-      }).to.throw(
-        "\n  error: Failed to open input file 'input-doesnot-exist'\n\n"
+      throws(
+        () => {
+          validations.validateArguments({
+            inputFrom: "input-doesnot-exist",
+            outputTo: "-",
+            outputType: "ast",
+          });
+        },
+        {
+          message:
+            "\n  error: Failed to open input file 'input-doesnot-exist'\n\n",
+        },
       );
     });
 
     it("'-T  -' complains about non specified output file", () => {
-      expect(() => {
-        validations.validateArguments({
-          inputFrom: "-",
-          outputType: "ast",
-        });
-      }).to.throw("\n  error: Please specify an output file.\n\n");
+      throws(
+        () => {
+          validations.validateArguments({
+            inputFrom: "-",
+            outputType: "ast",
+          });
+        },
+        { message: "\n  error: Please specify an output file.\n\n" },
+      );
     });
 
     it("complains about non specified input file", () => {
-      expect(() => {
-        validations.validateArguments({});
-      }).to.throw("\n  error: Please specify an input file.\n\n");
+      throws(
+        () => {
+          validations.validateArguments({});
+        },
+        { message: "\n  error: Please specify an input file.\n\n" },
+      );
     });
   });
 });

--- a/test/index.spec.mts
+++ b/test/index.spec.mts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual, throws } from "node:assert";
 import fastxml from "fast-xml-parser";
 import smcat from "../src/index.mjs";
 import smcat_node from "../src/index-node.mjs";
@@ -8,18 +8,19 @@ import { createRequireJSON } from "./utl.mjs";
 const $package = createRequireJSON(import.meta.url)("../package.json");
 const gXMLParser = new fastxml.XMLParser();
 
-describe("integration - regular esm", () => {
+describe("integration - regular esm [a]", () => {
   it("returned version corresponds with the package's", () => {
-    expect(smcat.version).to.equal($package.version);
+    strictEqual(smcat.version, $package.version);
   });
 
   it("'echoes' the input when -I smcat -T smcat", () => {
-    expect(
+    strictEqual(
       smcat.render("a;\n", {
         inputType: "smcat",
         outputType: "smcat",
       }),
-    ).to.equal("a;\n\n");
+      "a;\n\n",
+    );
   });
 
   it("returns svg and assumes smcat when no options passed", () => {
@@ -58,25 +59,26 @@ describe("integration - regular esm", () => {
   });
 
   it("accepts json as input", () => {
-    expect(
+    strictEqual(
       smcat.render('{"states":[{"name":"a", "type":"regular"}]}', {
         inputType: "json",
         outputType: "smcat",
       }),
-    ).to.equal("a;\n\n");
+      "a;\n\n",
+    );
   });
 
   it("throws when a passed JSON is not a valid AST", () => {
-    expect(() => {
+    throws(() => {
       smcat.render('{"states":[{"name":"a", "type":"non-existent-type"}]}', {
         inputType: "json",
         outputType: "smcat",
       });
-    }).to.throw();
+    });
   });
 
   it("accepts javascript objects as input", () => {
-    expect(
+    strictEqual(
       smcat.render(
         {
           states: [
@@ -91,11 +93,12 @@ describe("integration - regular esm", () => {
           outputType: "smcat",
         },
       ),
-    ).to.equal("a;\n\n");
+      "a;\n\n",
+    );
   });
 
   it("throws when a passed javascript object is not a valid AST", () => {
-    expect(() => {
+    throws(() => {
       smcat.render(
         {
           states: [
@@ -110,23 +113,24 @@ describe("integration - regular esm", () => {
           outputType: "smcat",
         },
       );
-    }).to.throw();
+    });
   });
 
   it("returns the ast for outputType === json", () => {
-    expect(
+    deepStrictEqual(
       smcat.render("a;", {
         inputType: "smcat",
         outputType: "json",
       }),
-    ).to.deep.equal({
-      states: [
-        {
-          name: "a",
-          type: "regular",
-        },
-      ],
-    });
+      {
+        states: [
+          {
+            name: "a",
+            type: "regular",
+          },
+        ],
+      },
+    );
   });
 
   it("returns the ast for inputTYpe === scxml, outputType === json", () => {
@@ -140,70 +144,73 @@ describe("integration - regular esm", () => {
             </state>
         </scxml>`;
 
-    expect(
+    deepStrictEqual(
       smcat.render(lSCXML, {
         inputType: "scxml",
         outputType: "json",
       }),
-    ).to.deep.equal({
-      states: [
-        {
-          name: "off",
-          type: "regular",
-        },
-        {
-          name: "on",
-          type: "regular",
-        },
-      ],
-      transitions: [
-        {
-          from: "off",
-          to: "on",
-          event: "switch_flipped",
-          label: "switch_flipped",
-        },
-        {
-          from: "on",
-          to: "off",
-          event: "switch_flipped",
-          label: "switch_flipped",
-        },
-      ],
-    });
+      {
+        states: [
+          {
+            name: "off",
+            type: "regular",
+          },
+          {
+            name: "on",
+            type: "regular",
+          },
+        ],
+        transitions: [
+          {
+            from: "off",
+            to: "on",
+            event: "switch_flipped",
+            label: "switch_flipped",
+          },
+          {
+            from: "on",
+            to: "off",
+            event: "switch_flipped",
+            label: "switch_flipped",
+          },
+        ],
+      },
+    );
   });
 
   it("desugars when asked to", () => {
-    expect(
+    strictEqual(
       smcat.render("a, ], b, c; a => ]; ] => b; ] => c;", {
         outputType: "smcat",
         desugar: true,
       }),
-    ).to.equal(`a,
+      `a,
 b,
 c;
 
 a => b;
 a => c;
-`);
+`,
+    );
   });
   it("desugars when asked to (node)", () => {
-    expect(
+    strictEqual(
       smcat_node.render("a, ], b, c; a => ]; ] => b; ] => c;", {
         outputType: "smcat",
         desugar: true,
       }),
-    ).to.equal(`a,
+      `a,
 b,
 c;
 
 a => b;
 a => c;
-`);
+`,
+    );
   });
 
   it("returns an object with allowed values", () => {
-    expect(smcat.getAllowedValues()).to.deep.equal(options.getAllowedValues());
+    deepStrictEqual(smcat.getAllowedValues(), options.getAllowedValues());
   });
 });
 /* eslint no-unused-expressions: 0 */

--- a/test/parse/scxml.spec.mts
+++ b/test/parse/scxml.spec.mts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
 import path from "node:path";
-import { expect } from "chai";
+import { deepStrictEqual, doesNotThrow, throws } from "node:assert";
 import Ajv from "ajv";
 
 import { parse } from "../../src/parse/scxml/index.mjs";
@@ -17,12 +17,13 @@ const FIXTURE_INPUTS = fs
   .filter((pFileName) => pFileName.endsWith(".scxml"))
   .map((pFileName) => path.join(FIXTURE_DIR, pFileName));
 
-describe("parse/scxml", () => {
+describe("parse/scxml [a]", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(pInputFixture)} to json`, () => {
       const lAST = parse(fs.readFileSync(pInputFixture, "utf8"));
 
-      expect(lAST).to.deep.equal(
+      deepStrictEqual(
+        lAST,
         JSON.parse(
           fs.readFileSync(
             pInputFixture.replace(/\.scxml$/g, ".scxml.re-json"),
@@ -30,7 +31,6 @@ describe("parse/scxml", () => {
           ),
         ),
       );
-      // ([^\)]+)
       ajv.validate($schema, lAST);
     });
   });
@@ -45,7 +45,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lStateWithAnInvoke);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "doing",
@@ -74,7 +74,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lStateWithAnInvoke);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "doing",
@@ -114,7 +114,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlWithTargetlessTransition);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "a",
@@ -143,7 +143,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlWithInitialNode);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "initial",
@@ -176,7 +176,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlWithInitialNode);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "door",
@@ -218,7 +218,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlOnentryWithXml);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "initial",
@@ -258,7 +258,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlOnexitWithXml);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "initial",
@@ -298,7 +298,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlTransitionWithXml);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "initial",
@@ -340,7 +340,7 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmTransitionToMultipleTargets);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal({
+    deepStrictEqual(lAST, {
       states: [
         {
           name: "initial",
@@ -434,20 +434,18 @@ describe("parse/scxml", () => {
     const lAST = parse(lScxmlTransitionFromCompoundParallelState);
 
     ajv.validate($schema, lAST);
-    expect(lAST).to.deep.equal(lExpectedAst);
+    deepStrictEqual(lAST, lExpectedAst);
   });
 
   it("barfs if the input is invalid xml", () => {
-    expect(() => parse("this is no xml")).to.throw(
-      "That doesn't look like valid xml",
-    );
+    throws(() => parse("this is no xml"), "That doesn't look like valid xml");
   });
 
   it("strips spaces before and after the xml content before parsing", () => {
-    expect(() =>
+    doesNotThrow(() =>
       parse(
         `     \n\n\n\n <?xml version="1.0" encoding="UTF-8"?><validxml></validxml>    \n\n     `,
       ),
-    ).to.not.throw();
+    );
   });
 });

--- a/test/parse/smcat-parser.spec.mts
+++ b/test/parse/smcat-parser.spec.mts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
-import { expect } from "chai";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import Ajv from "ajv";
 import { parse as parseSmCat } from "../../src/parse/smcat/smcat-parser.mjs";
 import $schema from "../../src/parse/smcat-ast.schema.mjs";
@@ -28,7 +28,7 @@ const syntaxErrors = requireJSON("./20-no-transitions-errors.json")
   .concat(requireJSON("./22-composition-errors.json"))
   .concat(requireJSON("./23-extra-attribute-errors.json"));
 
-describe("#parse() - happy day ASTs - ", () => {
+describe("#parse() - happy day ASTs - [a]", () => {
   programASTPairs.forEach((pPair) => {
     if (
       Object.prototype.hasOwnProperty.call(pPair, "pending") &&
@@ -41,13 +41,13 @@ describe("#parse() - happy day ASTs - ", () => {
         const lAST = parseSmCat(pPair.program);
 
         ajv.validate($schema, lAST);
-        expect(lAST).to.deep.equal(pPair.ast);
+        deepStrictEqual(lAST, pPair.ast);
       });
     }
   });
 });
 
-describe("#parse() - file based - ", () => {
+describe("#parse() - file based - [a] ", () => {
   fileBasedPairs.forEach((pPair) => {
     it(pPair.title, () => {
       const lProgram = readFileSync(
@@ -57,7 +57,7 @@ describe("#parse() - file based - ", () => {
       const lAST = parseSmCat(lProgram);
 
       ajv.validate($schema, lAST);
-      expect(lAST).to.deep.equal(requireJSON(`./${pPair.astFixtureFile}`));
+      deepStrictEqual(lAST, requireJSON(`./${pPair.astFixtureFile}`));
     });
   });
 });
@@ -72,13 +72,13 @@ function assertSyntaxError(pProgram, pParseFunction, pErrorType) {
     if (pParseFunction(pProgram)) {
       lStillRan = true;
     }
-    expect(lStillRan).to.equal(false);
+    strictEqual(lStillRan, false);
   } catch (pError) {
-    expect(pError.name).to.equal(pErrorType);
+    strictEqual(pError.name, pErrorType);
   }
 }
 
-describe("#parse() - syntax errors - ", () => {
+describe("#parse() - syntax errors - [a] ", () => {
   syntaxErrors.forEach((pPair) => {
     it(pPair.title, () => {
       assertSyntaxError(pPair.program, parseSmCat, pPair.error);
@@ -86,16 +86,17 @@ describe("#parse() - syntax errors - ", () => {
   });
 });
 
-describe("#parse() - parses the kitchensink", () => {
+describe("#parse() - parses the kitchensink [a]", () => {
   it("parses the kitchensink", () => {
-    expect(
+    deepStrictEqual(
       parseSmCat(
         readFileSync(
           fileURLToPath(new URL("fixtures/kitchensink.smcat", import.meta.url)),
           "utf8",
         ),
       ),
-    ).to.deep.equal(requireJSON("./fixtures/kitchensink.json"));
+      requireJSON("./fixtures/kitchensink.json"),
+    );
   });
 });
 /* eslint max-nested-callbacks: 0 */

--- a/test/render/dot/attributebuilder.spec.mts
+++ b/test/render/dot/attributebuilder.spec.mts
@@ -1,91 +1,97 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import attributebuilder from "../../../src/render/dot/attributebuilder.mjs";
 
-describe("attributebuilder", () => {
+describe("attributebuilder [a] ", () => {
   describe("buildGraphAttributes", () => {
     it("returns the generic attributes when no engine or direction is passed", () => {
-      expect(attributebuilder.buildGraphAttributes()).to.equal(
-        'fontname="Helvetica" fontsize=12 penwidth=2.0'
+      strictEqual(
+        attributebuilder.buildGraphAttributes(),
+        'fontname="Helvetica" fontsize=12 penwidth=2.0',
       );
     });
 
     it("returns the generic attributes when an unknown engine is passed", () => {
-      expect(
-        attributebuilder.buildGraphAttributes("not a known engine")
-      ).to.equal('fontname="Helvetica" fontsize=12 penwidth=2.0');
+      strictEqual(
+        attributebuilder.buildGraphAttributes("not a known engine"),
+        'fontname="Helvetica" fontsize=12 penwidth=2.0',
+      );
     });
 
     it("returns the generic attributes when an unknown engine and direction are passed", () => {
-      expect(
+      strictEqual(
         attributebuilder.buildGraphAttributes(
           "not a known engine",
-          "diagon ally"
-        )
-      ).to.equal('fontname="Helvetica" fontsize=12 penwidth=2.0');
+          "diagon ally",
+        ),
+        'fontname="Helvetica" fontsize=12 penwidth=2.0',
+      );
     });
 
     it("returns the fdp attributes when fdp is passed as an engine ", () => {
-      expect(attributebuilder.buildGraphAttributes("fdp")).to.equal(
-        'fontname="Helvetica" fontsize=12 penwidth=2.0 K=0.9'
+      strictEqual(
+        attributebuilder.buildGraphAttributes("fdp"),
+        'fontname="Helvetica" fontsize=12 penwidth=2.0 K=0.9',
       );
     });
 
     it("returns a rankdir when passed left-right as a direction", () => {
-      expect(
+      strictEqual(
         attributebuilder.buildGraphAttributes(
           "not a known engine",
-          "left-right"
-        )
-      ).to.equal('fontname="Helvetica" fontsize=12 penwidth=2.0 rankdir=LR');
+          "left-right",
+        ),
+        'fontname="Helvetica" fontsize=12 penwidth=2.0 rankdir=LR',
+      );
     });
 
     it("appends graph attributes when these get passed", () => {
-      expect(
+      strictEqual(
         attributebuilder.buildGraphAttributes("not a known engine", null, [
           { name: "bgcolor", value: "pink" },
           { name: "ratio", value: 1 },
-        ])
-      ).to.equal(
-        'fontname="Helvetica" fontsize=12 penwidth=2.0 bgcolor=pink ratio=1'
+        ]),
+        'fontname="Helvetica" fontsize=12 penwidth=2.0 bgcolor=pink ratio=1',
       );
     });
   });
 
-  describe("buildNodeAttributes", () => {
+  describe("buildNodeAttributes [a] ", () => {
     it("returns the generic attributes nothing is passed", () => {
-      expect(attributebuilder.buildNodeAttributes()).to.equal(
-        'shape=plaintext style=filled fillcolor="#FFFFFF01" fontname=Helvetica fontsize=12 penwidth=2.0'
+      strictEqual(
+        attributebuilder.buildNodeAttributes(),
+        'shape=plaintext style=filled fillcolor="#FFFFFF01" fontname=Helvetica fontsize=12 penwidth=2.0',
       );
     });
     it("appends attributes when these are passed", () => {
-      expect(
+      strictEqual(
         attributebuilder.buildNodeAttributes([
           {
             name: "foo",
             value: "bar",
           },
-        ])
-      ).to.equal(
-        'shape=plaintext style=filled fillcolor="#FFFFFF01" fontname=Helvetica fontsize=12 penwidth=2.0 foo=bar'
+        ]),
+        'shape=plaintext style=filled fillcolor="#FFFFFF01" fontname=Helvetica fontsize=12 penwidth=2.0 foo=bar',
       );
     });
   });
 
-  describe("buildEdgeAttributes", () => {
+  describe("buildEdgeAttributes [a] ", () => {
     it("returns the generic attributes nothing is passed", () => {
-      expect(attributebuilder.buildEdgeAttributes()).to.equal(
-        "fontname=Helvetica fontsize=10"
+      strictEqual(
+        attributebuilder.buildEdgeAttributes(),
+        "fontname=Helvetica fontsize=10",
       );
     });
     it("appends attributes when these are passed", () => {
-      expect(
+      strictEqual(
         attributebuilder.buildEdgeAttributes([
           {
             name: "baz",
             value: "qux",
           },
-        ])
-      ).to.equal("fontname=Helvetica fontsize=10 baz=qux");
+        ]),
+        "fontname=Helvetica fontsize=10 baz=qux",
+      );
     });
   });
 });

--- a/test/render/dot/counter.spec.mts
+++ b/test/render/dot/counter.spec.mts
@@ -1,36 +1,37 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import Counter from "../../../src/render/dot/counter.mjs";
 
-describe("counter", () => {
+describe("counter [a] ", () => {
   it("starts as 0", () => {
     const lCounter = new Counter();
 
-    expect(lCounter.next()).to.equal(1);
+    strictEqual(lCounter.next(), 1);
   });
 
   it("next calls increase", () => {
     const lCounter = new Counter();
 
-    expect(lCounter.next()).to.equal(1);
-    expect(lCounter.next()).to.equal(2);
-    expect(lCounter.next()).to.equal(3);
+    strictEqual(lCounter.next(), 1);
+    // expect\(lCounter.next\(\)\)\.to\.equal\(([^)]+)\);
+    strictEqual(lCounter.next(), 2);
+    strictEqual(lCounter.next(), 3);
   });
 
   it("resets to 0", () => {
     const lCounter = new Counter();
 
-    expect(lCounter.next()).to.equal(1);
-    expect(lCounter.next()).to.equal(2);
-    expect(lCounter.next()).to.equal(3);
+    strictEqual(lCounter.next(), 1);
+    strictEqual(lCounter.next(), 2);
+    strictEqual(lCounter.next(), 3);
     lCounter.reset();
-    expect(lCounter.next()).to.equal(1);
+    strictEqual(lCounter.next(), 1);
   });
 
   it("nextAsString calls increase and returns the result stringified in base10", () => {
     const lCounter = new Counter();
 
-    expect(lCounter.nextAsString()).to.equal("1");
-    expect(lCounter.nextAsString()).to.equal("2");
-    expect(lCounter.nextAsString()).to.equal("3");
+    strictEqual(lCounter.nextAsString(), "1");
+    strictEqual(lCounter.nextAsString(), "2");
+    strictEqual(lCounter.nextAsString(), "3");
   });
 });

--- a/test/render/dot/index.spec.mts
+++ b/test/render/dot/index.spec.mts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import convert from "../../../src/render/dot/index.mjs";
 import { createRequireJSON } from "../../utl.mjs";
 
@@ -168,20 +168,19 @@ const TEST_PAIRS = [
   },
 ];
 
-describe("render/dot - integration", () => {
+describe("render/dot - integration [a]", () => {
   TEST_PAIRS.forEach((pPair) =>
     it(pPair.title, () => {
-      expect(
+      strictEqual(
         convert(requireJSON(pPair.input), pPair.options || {}).replace(
           /\r\n/g,
-          "\n"
-        )
-      ).to.equal(
+          "\n",
+        ),
         fs.readFileSync(
           fileURLToPath(new URL(pPair.expectedOutput, import.meta.url)),
-          "utf8"
-        )
+          "utf8",
+        ),
       );
-    })
+    }),
   );
 });

--- a/test/render/dot/state-transformers.spec.mts
+++ b/test/render/dot/state-transformers.spec.mts
@@ -1,31 +1,36 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import stateTransformers from "../../../src/render/dot/state-transformers.mjs";
 
-describe("render/dot/state-transformers - classifyState", () => {
+describe("render/dot/state-transformers - classifyState [a] ", () => {
   it("by default, states get 'state' and their type as a class attribute", () => {
-    expect(stateTransformers.classifyState({ type: "regular" })).to.deep.equal({
+    deepStrictEqual(stateTransformers.classifyState({ type: "regular" }), {
       type: "regular",
       class: "state regular",
     });
   });
   it("when  default, states get 'state' and their type as a class attribute", () => {
-    expect(
-      stateTransformers.classifyState({ type: "junction", class: "petty coat" })
-    ).to.deep.equal({
-      type: "junction",
-      class: "state junction petty coat",
-    });
+    deepStrictEqual(
+      stateTransformers.classifyState({
+        type: "junction",
+        class: "petty coat",
+      }),
+      {
+        type: "junction",
+        class: "state junction petty coat",
+      },
+    );
   });
 
   it("class fields get trimmed and cleaned of superfluous spaces", () => {
-    expect(
+    deepStrictEqual(
       stateTransformers.classifyState({
         type: "regular",
         class: "   lotsa  space     before between   and after     ",
-      })
-    ).to.deep.equal({
-      type: "regular",
-      class: "state regular lotsa space before between and after",
-    });
+      }),
+      {
+        type: "regular",
+        class: "state regular lotsa space before between and after",
+      },
+    );
   });
 });

--- a/test/render/dot/transition-transformers.spec.mts
+++ b/test/render/dot/transition-transformers.spec.mts
@@ -1,48 +1,52 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import transitionTransformers from "../../../src/render/dot/transition-transformers.mjs";
 
-describe("render/dot/transition-transformers - classifyState", () => {
+describe("render/dot/transition-transformers - classifyState [a]", () => {
   it("by default, transitions get 'transition' as a class attribute", () => {
-    expect(transitionTransformers.classifyTransition({})).to.deep.equal({
+    deepStrictEqual(transitionTransformers.classifyTransition({}), {
       class: "transition",
     });
   });
   it("transitions get 'transition' and their type as a class attribute when they have an explicit type", () => {
-    expect(
-      transitionTransformers.classifyTransition({ type: "external" })
-    ).to.deep.equal({
-      type: "external",
-      class: "transition external",
-    });
+    deepStrictEqual(
+      transitionTransformers.classifyTransition({ type: "external" }),
+      {
+        type: "external",
+        class: "transition external",
+      },
+    );
   });
   it("transitions with a class attribute get the default class attributes for a transition + that class", () => {
-    expect(
+    deepStrictEqual(
       transitionTransformers.classifyTransition({
         class: "petty coat",
-      })
-    ).to.deep.equal({
-      class: "transition petty coat",
-    });
+      }),
+      {
+        class: "transition petty coat",
+      },
+    );
   });
 
   it("transitions with a class attribute & an explicit type get the default class attributes for a transition + that class", () => {
-    expect(
+    deepStrictEqual(
       transitionTransformers.classifyTransition({
         type: "internal",
         class: "petty coat",
-      })
-    ).to.deep.equal({
-      type: "internal",
-      class: "transition internal petty coat",
-    });
+      }),
+      {
+        type: "internal",
+        class: "transition internal petty coat",
+      },
+    );
   });
   it("class fields get trimmed and cleaned of superfluous spaces", () => {
-    expect(
+    deepStrictEqual(
       transitionTransformers.classifyTransition({
         class: "   lotsa  space     before between   and after     ",
-      })
-    ).to.deep.equal({
-      class: "transition lotsa space before between and after",
-    });
+      }),
+      {
+        class: "transition lotsa space before between and after",
+      },
+    );
   });
 });

--- a/test/render/dot/utl.spec.mts
+++ b/test/render/dot/utl.spec.mts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import utl from "../../../src/render/dot/utl.mjs";
 import StateMachineModel from "../../../src/state-machine-model.mjs";
 
@@ -43,38 +43,36 @@ const AST = {
   ],
 };
 
-describe("utl.isCompositeSelf", () => {
+describe("utl.isCompositeSelf [a] ", () => {
   const lModel = new StateMachineModel(AST);
 
   it("returns false when from !== to and neither is composite", () => {
-    expect(utl.isCompositeSelf(lModel, { from: "a.a", to: "a.b" })).to.equal(
-      false
-    );
+    strictEqual(utl.isCompositeSelf(lModel, { from: "a.a", to: "a.b" }), false);
   });
 
   it("returns false when from !== to and both are composite", () => {
-    expect(utl.isCompositeSelf(lModel, { from: "a", to: "b" })).to.equal(false);
+    strictEqual(utl.isCompositeSelf(lModel, { from: "a", to: "b" }), false);
   });
 
   it("returns false when from === to and it's not composite", () => {
-    expect(utl.isCompositeSelf(lModel, { from: "a.a", to: "a.a" })).to.equal(
-      false
-    );
+    strictEqual(utl.isCompositeSelf(lModel, { from: "a.a", to: "a.a" }), false);
   });
 
   it("returns false when from === to and it's composite but internal", () => {
-    expect(
-      utl.isCompositeSelf(lModel, { from: "a", to: "a", type: "internal" })
-    ).to.equal(false);
+    strictEqual(
+      utl.isCompositeSelf(lModel, { from: "a", to: "a", type: "internal" }),
+      false,
+    );
   });
 
   it("returns true when from === to and it's composite", () => {
-    expect(utl.isCompositeSelf(lModel, { from: "a", to: "a" })).to.equal(true);
+    strictEqual(utl.isCompositeSelf(lModel, { from: "a", to: "a" }), true);
   });
 
   it("returns true when from === to and it's composite (explicitly set)", () => {
-    expect(
-      utl.isCompositeSelf(lModel, { from: "a", to: "a", type: "external" })
-    ).to.equal(true);
+    strictEqual(
+      utl.isCompositeSelf(lModel, { from: "a", to: "a", type: "external" }),
+      true,
+    );
   });
 });

--- a/test/render/json.spec.mts
+++ b/test/render/json.spec.mts
@@ -15,7 +15,7 @@ const FIXTURE_INPUTS = readdirSync(FIXTURE_DIR)
   .filter((pFileName) => pFileName.endsWith(".smcat"))
   .map((pFileName) => join(FIXTURE_DIR, pFileName));
 
-describe("#parse smcat to json - ", () => {
+describe("#parse smcat to json - [a] ", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly parses ${basename(pInputFixture)} into json`, () => {
       const lResult = convert(readFileSync(pInputFixture, "utf8"));

--- a/test/render/scjson/index.spec.mts
+++ b/test/render/scjson/index.spec.mts
@@ -14,7 +14,7 @@ const FIXTURE_INPUTS = fs
   .filter((pFileName) => pFileName.endsWith(".json"))
   .map((pFileName) => path.join(FIXTURE_DIR, pFileName));
 
-describe("#ast2scjson - ", () => {
+describe("#ast2scjson - [a] ", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(pInputFixture)} to scjson`, () => {
       const lResult = convert(

--- a/test/render/scjson/make-valid-event-names.spec.mts
+++ b/test/render/scjson/make-valid-event-names.spec.mts
@@ -1,13 +1,13 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import makeValidEventNames from "../../../src/render/scjson/make-valid-event-names.mjs";
 
 function checkExpectation(pExpectation, pValue) {
   const lValueToTest = makeValidEventNames(pValue);
 
-  expect(lValueToTest).to.equal(pExpectation);
+  strictEqual(lValueToTest, pExpectation);
 }
 
-describe("#makeValidEventNames", () => {
+describe("#makeValidEventNames [a]", () => {
   it("returns an empty when not passed a value", () => {
     checkExpectation("empty");
   });
@@ -31,7 +31,7 @@ describe("#makeValidEventNames", () => {
   it("replaces any space likes with a regular space", () => {
     checkExpectation(
       "aap_noot_mies wim zus jet",
-      "aap\t\t\tnoot mies\nwim\n\n\rzus\rjet"
+      "aap\t\t\tnoot mies\nwim\n\n\rzus\rjet",
     );
   });
 
@@ -60,7 +60,7 @@ describe("#makeValidEventNames", () => {
   it("smoke test", () => {
     checkExpectation(
       "3.little.小豬 有限._狀態機",
-      "3.little.小豬\n有限.·狀態機\r\n"
+      "3.little.小豬\n有限.·狀態機\r\n",
     );
   });
 });

--- a/test/render/scjson/make-valid-xml-name.spec.mts
+++ b/test/render/scjson/make-valid-xml-name.spec.mts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
+import { strictEqual } from "node:assert";
 import XMLNameValidator from "xml-name-validator";
 import makeValidXMLName from "../../../src/render/scjson/make-valid-xml-name.mjs";
 
 function checkExpectationAndValidity(pExpectation, pValue) {
   const lValueToTest = makeValidXMLName(pValue);
 
-  expect(lValueToTest).to.equal(pExpectation);
-  expect(XMLNameValidator.name(lValueToTest)).to.equal(true);
+  strictEqual(lValueToTest, pExpectation);
+  strictEqual(XMLNameValidator.name(lValueToTest), true);
 }
 
-describe("#makeValidXMLName", () => {
+describe("#makeValidXMLName [a]", () => {
   it("returns an __empty when not passed a value", () => {
     checkExpectationAndValidity("__empty");
   });

--- a/test/render/scxml.spec.mts
+++ b/test/render/scxml.spec.mts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import convert from "../../src/render/scxml/index.mjs";
 
 const FIXTURE_DIR = fileURLToPath(new URL("fixtures", import.meta.url));
@@ -10,13 +10,12 @@ const FIXTURE_INPUTS = fs
   .filter((pFileName) => pFileName.endsWith(".json"))
   .map((pFileName) => path.join(FIXTURE_DIR, pFileName));
 
-describe("#ast2scxml - integration - ", () => {
+describe("#ast2scxml - integration - [a] ", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(pInputFixture)} to scxml`, () => {
-      expect(
-        convert(JSON.parse(fs.readFileSync(pInputFixture, "utf8")))
-      ).to.deep.equal(
-        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".scxml"), "utf8")
+      deepStrictEqual(
+        convert(JSON.parse(fs.readFileSync(pInputFixture, "utf8"))),
+        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".scxml"), "utf8"),
       );
     });
   });

--- a/test/render/smcat.spec.mts
+++ b/test/render/smcat.spec.mts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import convert from "../../src/render/smcat/index.mjs";
 import { parse } from "../../src/parse/smcat/smcat-parser.mjs";
 import { createRequireJSON } from "../utl.mjs";
@@ -14,7 +14,7 @@ const programASTPairs = requireJSON("../parse/00-no-transitions.json")
   .concat(requireJSON("../parse/07-type.json"))
   .concat(requireJSON("../parse/08-transition-type.json"));
 
-describe("#parse(convert) - happy day ASTs - ", () => {
+describe("#parse(convert) - happy day ASTs - [a] ", () => {
   programASTPairs.forEach((pPair) => {
     if (
       Object.prototype.hasOwnProperty.call(pPair, "pending") &&
@@ -24,7 +24,7 @@ describe("#parse(convert) - happy day ASTs - ", () => {
       xit(pPair.title);
     } else {
       it(pPair.title, () => {
-        expect(parse(convert(pPair.ast))).to.deep.equal(pPair.ast);
+        deepStrictEqual(parse(convert(pPair.ast)), pPair.ast);
       });
     }
   });

--- a/test/render/vector/dot-to-vector-native.spec.mts
+++ b/test/render/vector/dot-to-vector-native.spec.mts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { strictEqual, throws } from "node:assert";
 import isPng from "is-png";
 import isPdf from "is-pdf";
 import dotToVector from "../../../src/render/vector/dot-to-vector-native.mjs";
@@ -6,55 +6,58 @@ import dotToVector from "../../../src/render/vector/dot-to-vector-native.mjs";
 if (dotToVector.isAvailable()) {
   describe("dot-to-svg-native - isAvailable", () => {
     it("returns false when the executable isn't available", () => {
-      expect(
+      strictEqual(
         dotToVector.isAvailable({
           exec: "this_executable_does_not_exist_in_the_path",
-        })
-      ).to.equal(false);
+        }),
+        false,
+      );
     });
     it("returns true when the executable is available", () => {
-      expect(
+      strictEqual(
         dotToVector.isAvailable({
           exec: "dot",
-        })
-      ).to.equal(true);
+        }),
+        true,
+      );
     });
   });
 
-  describe("dot-to-vector-native - convert", () => {
+  describe("dot-to-vector-native - convert [a]", () => {
     it("renders an svg when presented with valid dot when no extra options passed", () => {
       const lFound = dotToVector.convert("digraph { a }");
 
-      expect(lFound).to.contain("<svg");
-      expect(lFound).to.contain("</svg>");
+      strictEqual(lFound.includes("<svg"), true);
+      // expect\(([^\)]+)\)\.to\.contain\(([^\)]+)\);
+      strictEqual(lFound.includes("</svg>"), true);
     });
 
     it("renders an svg when presented with valid dot when svg is passed as an explicit option", () => {
       const lFound = dotToVector.convert("digraph { a }", { format: "svg" });
 
-      expect(lFound).to.contain("<svg");
-      expect(lFound).to.contain("</svg>");
+      strictEqual(lFound.includes("<svg"), true);
+      strictEqual(lFound.includes("</svg>"), true);
     });
 
     it("renders postscript when presented with valid dot when ps is passed as an option", () => {
       const lFound = dotToVector.convert("digraph { a }", { format: "ps" });
 
-      expect(lFound).to.contain("%!PS-Adobe-3.0");
-      expect(lFound).to.contain("%%EOF");
+      strictEqual(lFound.includes("%!PS-Adobe-3.0"), true);
+      strictEqual(lFound.includes("%%EOF"), true);
     });
 
     it("renders postscript when presented with valid dot when ps2 is passed as an option", () => {
       const lFound = dotToVector.convert("digraph { a }", { format: "ps2" });
 
-      expect(lFound).to.contain("%!PS-Adobe-3.0");
-      expect(lFound).to.contain("%%EOF");
+      strictEqual(lFound.includes("%!PS-Adobe-3.0"), true);
+      strictEqual(lFound.includes("%%EOF"), true);
     });
 
     it("renders encapsulated postscript when presented with valid dot when eps is passed as an option", () => {
       const lFound = dotToVector.convert("digraph { a }", { format: "eps" });
 
-      expect(lFound).to.contain("%!PS-Adobe-3.0 EPSF-3.0");
-      expect(lFound).to.contain("%%EOF");
+      strictEqual(lFound.includes("%!PS-Adobe-3.0 EPSF-3.0"), true);
+      strictEqual(lFound.includes("%%EOF"), true);
     });
 
     it("renders png when presented with valid dot when png is passed as an option", () => {
@@ -63,7 +66,7 @@ if (dotToVector.isAvailable()) {
       });
       const lFoundAsBuffer = Buffer.from(lFound, "binary");
 
-      expect(isPng(lFoundAsBuffer)).to.equal(true);
+      strictEqual(isPng(lFoundAsBuffer), true);
     });
 
     it("renders pdf when presented with valid dot when pdf is passed as an option", () => {
@@ -72,22 +75,20 @@ if (dotToVector.isAvailable()) {
       });
       const lFoundAsBuffer = Buffer.from(lFound, "binary");
 
-      expect(isPdf(lFoundAsBuffer)).to.equal(true);
+      strictEqual(isPdf(lFoundAsBuffer), true);
     });
 
     it("throws an error when presented with an invalid dot", () => {
-      expect(() => {
+      throws(() => {
         dotToVector.convert("this ain't no dot program");
-      }).to.throw("Unexpected error occurred. Exit code 1");
+      }, /Unexpected error occurred\. Exit code 1/);
     });
     it("throws an error when it can't find the executable", () => {
-      expect(() => {
+      throws(() => {
         dotToVector.convert("digraph { a }", {
           exec: "this_executable_does_not_exist_in_the_path",
         });
-      }).to.throw(
-        "Error: spawnSync this_executable_does_not_exist_in_the_path ENOENT"
-      );
+      }, /Error: spawnSync this_executable_does_not_exist_in_the_path ENOENT/);
     });
   });
 }

--- a/test/render/vector/vector-native-dot-with-fallback.spec.mts
+++ b/test/render/vector/vector-native-dot-with-fallback.spec.mts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { strictEqual, throws } from "node:assert";
 import dotToSVG from "../../../src/render/vector/vector-native-dot-with-fallback.mjs";
 
 const AST = {
@@ -20,12 +20,12 @@ const AST = {
   ],
 };
 
-describe("svg-native-dot-with-fallback", () => {
+describe("svg-native-dot-with-fallback [a]", () => {
   it("returns an SVG when the 'dot' program exists and is in the path", () => {
     const lOutput = dotToSVG(AST);
 
-    expect(lOutput).to.contain("<svg");
-    expect(lOutput).to.contain("</svg>");
+    strictEqual(lOutput.includes("<svg"), true);
+    strictEqual(lOutput.includes("</svg>"), true);
   });
 
   it("returns an SVG when the 'dot' program doesn't exist", () => {
@@ -34,16 +34,16 @@ describe("svg-native-dot-with-fallback", () => {
       noDotNativeWarning: true,
     });
 
-    expect(lOutput).to.contain("<svg");
-    expect(lOutput).to.contain("</svg>");
+    strictEqual(lOutput.includes("<svg"), true);
+    strictEqual(lOutput.includes("</svg>"), true);
   });
 
   it("throws when the 'dot' program doesn't exists and format not supported by the wasm fall back is requested", () => {
-    expect(() => {
+    throws(() => {
       dotToSVG(AST, {
         exec: "this_executable_does_not_exist_for_sure",
         outputType: "png",
       });
-    }).to.throw();
+    });
   });
 });

--- a/test/render/vector/vector-with-wasm.spec.mts
+++ b/test/render/vector/vector-with-wasm.spec.mts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import convert from "../../../src/render/vector/vector-with-wasm.mjs";
 
 /**
@@ -25,50 +25,53 @@ const FIXTURE_INPUTS = fs
   .filter((pFileName) => isDeterministic(pFileName))
   .map((pFileName) => path.join(FIXTURE_DIR, pFileName));
 
-describe("#ast2svg-with-wasm - integration - ", () => {
+describe("#ast2svg-with-wasm - integration - [a]", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(pInputFixture)} to svg`, () => {
       const lResult = convert(
         JSON.parse(fs.readFileSync(pInputFixture, "utf8")),
-        { engine: "dot" }
+        { engine: "dot" },
       );
 
-      expect(lResult).to.deep.equal(
-        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".svg"), "utf8")
+      deepStrictEqual(
+        lResult,
+        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".svg"), "utf8"),
       );
     });
   });
 });
 
-describe("#ast2ps2-with-wasm - integration - ", () => {
+describe("#ast2ps2-with-wasm - integration - [a]", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(
-      pInputFixture
+      pInputFixture,
     )} to postscript`, () => {
       const lResult = convert(
         JSON.parse(fs.readFileSync(pInputFixture, "utf8")),
-        { outputType: "oldps2" }
+        { outputType: "oldps2" },
       );
 
-      expect(lResult).to.deep.equal(
-        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".ps"), "utf8")
+      deepStrictEqual(
+        lResult,
+        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".ps"), "utf8"),
       );
     });
   });
 });
 
-describe("#ast2eps-with-wasm - integration - ", () => {
+describe("#ast2eps-with-wasm - integration - [a]", () => {
   FIXTURE_INPUTS.forEach((pInputFixture) => {
     it(`correctly converts ${path.basename(
-      pInputFixture
+      pInputFixture,
     )} to encapsulated postscript`, () => {
       const lResult = convert(
         JSON.parse(fs.readFileSync(pInputFixture, "utf8")),
-        { outputType: "oldeps" }
+        { outputType: "oldeps" },
       );
 
-      expect(lResult).to.deep.equal(
-        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".eps"), "utf8")
+      deepStrictEqual(
+        lResult,
+        fs.readFileSync(pInputFixture.replace(/\.json$/g, ".eps"), "utf8"),
       );
     });
   });

--- a/test/state-machine-model.spec.mts
+++ b/test/state-machine-model.spec.mts
@@ -1,28 +1,29 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import SMModel from "../src/state-machine-model.mjs";
 import { createRequireJSON } from "./utl.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 
-describe("#StateMachineModel - findStateByName", () => {
+describe("#StateMachineModel - findStateByName [a]", () => {
   requireJSON("./ast-massage-02-find-state-by-name.json").forEach((pPair) =>
     it(pPair.title, () => {
       const lSMModel = new SMModel(pPair.inputHaystack);
 
-      expect(lSMModel.findStateByName(pPair.inputNeedle)).to.deep.equal(
-        pPair.expectedOutput
+      deepStrictEqual(
+        lSMModel.findStateByName(pPair.inputNeedle),
+        pPair.expectedOutput,
       );
-    })
+    }),
   );
 });
 
-describe("#StateMachineModel - flattenTransitions", () => {
+describe("#StateMachineModel - flattenTransitions [a]", () => {
   requireJSON("./ast-massage-03-flatten-transitions.json").forEach((pPair) =>
     it(pPair.title, () => {
       const lSMModel = new SMModel(pPair.input);
 
-      expect(lSMModel.flattenedTransitions).to.deep.equal(pPair.expectedOutput);
-    })
+      deepStrictEqual(lSMModel.flattenedTransitions, pPair.expectedOutput);
+    }),
   );
 });
 

--- a/test/transform/desugar-forks.spec.mts
+++ b/test/transform/desugar-forks.spec.mts
@@ -1,51 +1,49 @@
-import chai from "chai";
+import { deepStrictEqual } from "node:assert";
 import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
 
-const expect = chai.expect;
-
-describe("transform/desugar - forks", () => {
+describe("transform/desugar - forks [a]", () => {
   it("replaces forks with the transitions they represent", () => {
     const WITHFORK = utl.readFixture("singlefork.json");
     const WITHOUTFORK = utl.readFixture("singlefork.desugared.json");
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 
   it("replaces forks in nested sms' with the transitions they represent", () => {
     const WITHFORK = utl.readFixture("singlenestedfork.json");
     const WITHOUTFORK = utl.readFixture("singlenestedfork.desugared.json");
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 
   it("replaces forks to sm's with the transitions they represent", () => {
     const WITHFORK = utl.readFixture("forkintonested.json");
     const WITHOUTFORK = utl.readFixture("forkintonested.desugared.json");
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 
   it("replaces forks to higher up levels with the transitions they represent", () => {
     const WITHFORK = utl.readFixture("forkfromnestedtohigherup.json");
     const WITHOUTFORK = utl.readFixture(
-      "forkfromnestedtohigherup.desugared.json"
+      "forkfromnestedtohigherup.desugared.json",
     );
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 
   it("merges incoming and outgoing actions", () => {
     const WITHFORK = utl.readFixture("forkmergeactions.json");
     const WITHOUTFORK = utl.readFixture("forkmergeactions.desugared.json");
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 
   it("uses the outgoing action if there's no incoming one", () => {
     const WITHFORK = utl.readFixture("forkuseoutgoingaction.json");
     const WITHOUTFORK = utl.readFixture("forkuseoutgoingaction.desugared.json");
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 });

--- a/test/transform/desugar-joins.spec.mts
+++ b/test/transform/desugar-joins.spec.mts
@@ -1,49 +1,49 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
 
-describe("transform/desugar - joins", () => {
+describe("transform/desugar - joins [a]", () => {
   it("replaces joins with the transitions they represent", () => {
     const WITHJOIN = utl.readFixture("singlejoin.json");
     const WITHOUTJOIN = utl.readFixture("singlejoin.desugared.json");
 
-    expect(desugar(WITHJOIN, ["join"])).to.deep.equal(WITHOUTJOIN);
+    deepStrictEqual(desugar(WITHJOIN, ["join"]), WITHOUTJOIN);
   });
 
   it("replaces joins in nested sms' with the transitions they represent", () => {
     const WITHJOIN = utl.readFixture("singlenestedjoin.json");
     const WITHOUTJOIN = utl.readFixture("singlenestedjoin.desugared.json");
 
-    expect(desugar(WITHJOIN, ["join"])).to.deep.equal(WITHOUTJOIN);
+    deepStrictEqual(desugar(WITHJOIN, ["join"]), WITHOUTJOIN);
   });
 
   it("replaces joins to sm's with the transitions they represent", () => {
     const WITHJOIN = utl.readFixture("joinintonested.json");
     const WITHOUTJOIN = utl.readFixture("joinintonested.desugared.json");
 
-    expect(desugar(WITHJOIN, ["join"])).to.deep.equal(WITHOUTJOIN);
+    deepStrictEqual(desugar(WITHJOIN, ["join"]), WITHOUTJOIN);
   });
 
   it("replaces joins to highr up sm's with the transitions they represent", () => {
     const WITHJOIN = utl.readFixture("joinfromnestedtohigherup.json");
     const WITHOUTJOIN = utl.readFixture(
-      "joinfromnestedtohigherup.desugared.json"
+      "joinfromnestedtohigherup.desugared.json",
     );
 
-    expect(desugar(WITHJOIN, ["join"])).to.deep.equal(WITHOUTJOIN);
+    deepStrictEqual(desugar(WITHJOIN, ["join"]), WITHOUTJOIN);
   });
 
   it("merges incoming and outgoing actions", () => {
     const WITHJOIN = utl.readFixture("joinmergeactions.json");
     const WITHOUTJOIN = utl.readFixture("joinmergeactions.desugared.json");
 
-    expect(desugar(WITHJOIN, ["join"])).to.deep.equal(WITHOUTJOIN);
+    deepStrictEqual(desugar(WITHJOIN, ["join"]), WITHOUTJOIN);
   });
 
   it("uses the outgoing action if there's no incoming one", () => {
     const WITHJOIN = utl.readFixture("joinuseoutgoingaction.json");
     const WITHOUTJOIN = utl.readFixture("joinuseoutgoingaction.desugared.json");
 
-    expect(desugar(WITHJOIN, ["join"])).to.deep.equal(WITHOUTJOIN);
+    deepStrictEqual(desugar(WITHJOIN, ["join"]), WITHOUTJOIN);
   });
 });

--- a/test/transform/desugar-junctions.spec.mts
+++ b/test/transform/desugar-junctions.spec.mts
@@ -1,31 +1,31 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
 
-describe("transform/desugar - junctions", () => {
+describe("transform/desugar - junctions [a]", () => {
   it("leaves empty state machines alone", () => {
     const lEmptyMachine = { states: [] };
 
-    expect(desugar(lEmptyMachine)).to.deep.equal(lEmptyMachine);
+    deepStrictEqual(desugar(lEmptyMachine), lEmptyMachine);
   });
 
   it("leaves state machines without pseudo states alone", () => {
     const JUNCTIONLESS = utl.readFixture("noforknojoin.json");
 
-    expect(desugar(JUNCTIONLESS)).to.deep.equal(JUNCTIONLESS);
+    deepStrictEqual(desugar(JUNCTIONLESS), JUNCTIONLESS);
   });
 
   it("replaces a single junctions with the transitions they represent", () => {
     const WITHJUNCTION = utl.readFixture("junction.json");
     const WITHOUTJUNCTION = utl.readFixture("junction.desugared.json");
 
-    expect(desugar(WITHJUNCTION)).to.deep.equal(WITHOUTJUNCTION);
+    deepStrictEqual(desugar(WITHJUNCTION), WITHOUTJUNCTION);
   });
 
   it("replaces a multiple junctions with the transitions they represent", () => {
     const WITHJUNCTION = utl.readFixture("junctions.json");
     const WITHOUTJUNCTION = utl.readFixture("junctions.desugared.json");
 
-    expect(desugar(WITHJUNCTION)).to.deep.equal(WITHOUTJUNCTION);
+    deepStrictEqual(desugar(WITHJUNCTION), WITHOUTJUNCTION);
   });
 });

--- a/test/transform/desugar.spec.mts
+++ b/test/transform/desugar.spec.mts
@@ -1,24 +1,24 @@
-import { expect } from "chai";
+import { deepStrictEqual } from "node:assert";
 import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
 
-describe("transform/desugar - forks", () => {
+describe("transform/desugar - forks [a]", () => {
   it("leaves empty state machines alone", () => {
     const lEmptyMachine = { states: [] };
 
-    expect(desugar(lEmptyMachine)).to.deep.equal(lEmptyMachine);
+    deepStrictEqual(desugar(lEmptyMachine), lEmptyMachine);
   });
 
   it("leaves state machines without forks alone", () => {
     const FORKLESS = utl.readFixture("noforknojoin.json");
 
-    expect(desugar(FORKLESS)).to.deep.equal(FORKLESS);
+    deepStrictEqual(desugar(FORKLESS), FORKLESS);
   });
 
   it("if there's > 1 pseudo state, don't duplicate transitions", () => {
     const WITHFORK = utl.readFixture("2pseudostates.json");
     const WITHOUTFORK = utl.readFixture("2pseudostates.desugared.json");
 
-    expect(desugar(WITHFORK)).to.deep.equal(WITHOUTFORK);
+    deepStrictEqual(desugar(WITHFORK), WITHOUTFORK);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,8 +50,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     "types": [
       "node",
-      "mocha",
-      "chai"
+      "mocha"
     ] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
## Description

- replaces chai with node:assert as assertion library

## Motivation and Context

- less dependencies === less worries - and node:assert is built into nodejs anyway

## How Has This Been Tested?

- [x] green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
