### PR TITLE
refactor(parse/smcat): removes (unused) ast emission code for comments, spaces and line-ends

### DIFF
--- a/dist/parse/smcat/smcat-parser.mjs
+++ b/dist/parse/smcat/smcat-parser.mjs
@@ -389,15 +389,6 @@ function peg$parse(input, options) {
     var peg$f38 = function (c) { return c; };
     var peg$f39 = function (c) { return c; };
     var peg$f40 = function (chars) { return chars.join(""); };
-    var peg$f41 = function (c) { return c; };
-    var peg$f42 = function (c) { return c; };
-    var peg$f43 = function (c) { return c; };
-    var peg$f44 = function (start, com, end) {
-        return start + com.join("") + end;
-    };
-    var peg$f45 = function (start, com) {
-        return start + com.join("");
-    };
     var peg$currPos = 0;
     var peg$savedPos = 0;
     var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -2673,22 +2664,16 @@ function peg$parse(input, options) {
     function peg$parsewhitespace() {
         var s0, s1;
         peg$silentFails++;
-        s0 = peg$currPos;
         if (peg$r3.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
+            s0 = input.charAt(peg$currPos);
             peg$currPos++;
         }
         else {
-            s1 = peg$FAILED;
+            s0 = peg$FAILED;
             if (peg$silentFails === 0) {
                 peg$fail(peg$e70);
             }
         }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$f41(s1);
-        }
-        s0 = s1;
         peg$silentFails--;
         if (s0 === peg$FAILED) {
             s1 = peg$FAILED;
@@ -2701,22 +2686,16 @@ function peg$parse(input, options) {
     function peg$parselineend() {
         var s0, s1;
         peg$silentFails++;
-        s0 = peg$currPos;
         if (peg$r4.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
+            s0 = input.charAt(peg$currPos);
             peg$currPos++;
         }
         else {
-            s1 = peg$FAILED;
+            s0 = peg$FAILED;
             if (peg$silentFails === 0) {
                 peg$fail(peg$e72);
             }
         }
-        if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$f42(s1);
-        }
-        s0 = s1;
         peg$silentFails--;
         if (s0 === peg$FAILED) {
             s1 = peg$FAILED;
@@ -2789,8 +2768,8 @@ function peg$parse(input, options) {
                 }
             }
             if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s0 = peg$f43(s2);
+                s1 = [s1, s2];
+                s0 = s1;
             }
             else {
                 peg$currPos = s0;
@@ -2816,8 +2795,8 @@ function peg$parse(input, options) {
             }
             s3 = peg$parsemlcomend();
             if (s3 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s0 = peg$f44(s1, s2, s3);
+                s1 = [s1, s2, s3];
+                s0 = s1;
             }
             else {
                 peg$currPos = s0;
@@ -2869,8 +2848,8 @@ function peg$parse(input, options) {
                 s2.push(s3);
                 s3 = peg$parseslcomtok();
             }
-            peg$savedPos = s0;
-            s0 = peg$f45(s1, s2);
+            s1 = [s1, s2];
+            s0 = s1;
         }
         else {
             peg$currPos = s0;

--- a/src/parse/smcat/peg/smcat-parser.peggy
+++ b/src/parse/smcat/peg/smcat-parser.peggy
@@ -271,29 +271,23 @@ identifier "identifier"
     / quotedstring
 
 whitespace "whitespace"
-    = c:[ \t] {return c}
+    = c:[ \t]
 
 lineend "line end"
-    = c:[\r\n] {return c}
+    = c:[\r\n]
 
 /* comments - multi line */
 mlcomstart = "/*"
 mlcomend   = "*/"
-mlcomtok   = !"*/" c:. {return c}
+mlcomtok   = !"*/" c:.
 mlcomment
     = start:mlcomstart com:(mlcomtok)* end:mlcomend
-    {
-      return start + com.join("") + end
-    }
 
 /* comments - single line */
 slcomstart = "//"
 slcomtok   = [^\r\n]
 slcomment
     = start:(slcomstart) com:(slcomtok)*
-    {
-      return start + com.join("")
-    }
 
 /* comments in general */
 comment "comment"

--- a/src/parse/smcat/smcat-parser.mjs
+++ b/src/parse/smcat/smcat-parser.mjs
@@ -436,15 +436,6 @@ function peg$parse(input, options) {
   var peg$f38 = function(c) {return c};
   var peg$f39 = function(c) {return c};
   var peg$f40 = function(chars) {return chars.join("")};
-  var peg$f41 = function(c) {return c};
-  var peg$f42 = function(c) {return c};
-  var peg$f43 = function(c) {return c};
-  var peg$f44 = function(start, com, end) {
-      return start + com.join("") + end
-    };
-  var peg$f45 = function(start, com) {
-      return start + com.join("")
-    };
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -2479,19 +2470,13 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    s0 = peg$currPos;
     if (peg$r3.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
+      s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
-      s1 = peg$FAILED;
+      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e70); }
     }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f41(s1);
-    }
-    s0 = s1;
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
@@ -2505,19 +2490,13 @@ function peg$parse(input, options) {
     var s0, s1;
 
     peg$silentFails++;
-    s0 = peg$currPos;
     if (peg$r4.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
+      s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
-      s1 = peg$FAILED;
+      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e72); }
     }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f42(s1);
-    }
-    s0 = s1;
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
@@ -2584,8 +2563,8 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e64); }
       }
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f43(s2);
+        s1 = [s1, s2];
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2612,8 +2591,8 @@ function peg$parse(input, options) {
       }
       s3 = peg$parsemlcomend();
       if (s3 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f44(s1, s2, s3);
+        s1 = [s1, s2, s3];
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2666,8 +2645,8 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$parseslcomtok();
       }
-      peg$savedPos = s0;
-      s0 = peg$f45(s1, s2);
+      s1 = [s1, s2];
+      s0 = s1;
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;


### PR DESCRIPTION
## Description

- removes (unused) AST emission code for comments, spaces and line-ends from the smcat parser

## Motivation and Context

Makes the parser code a little bit smaller, probably a tiny bit faster - and a little easier to understand.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
