### PR TITLE
ci!: drops support for node 16 and 19 - BREAKING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 20.x]
+        node-version: [18.x, 20.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{matrix.platform}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "xml-name-validator": "4.0.0"
       },
       "engines": {
-        "node": "^16.14||>=18"
+        "node": "^18.17||>=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "xml-name-validator": "4.0.0"
   },
   "engines": {
-    "node": "^16.14||>=18"
+    "node": "^18.17||>=20"
   },
   "types": "types/state-machine-cat.d.ts",
   "browserslist": [


### PR DESCRIPTION
## Description

- see title

## Motivation and Context

Follow nodejs release cycle

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
