### PR TITLE
refactor(test): starts using subpath imports in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
       }
     ]
   },
+  "imports": {
+    "#*": "./src/*"
+  },
   "sideEffects": [
     "dist/render/smcat/smcat.template.js",
     "dist/render/dot/dot.states.template.js",

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { equal } from "node:assert/strict";
-import * as actions from "../../src/cli/actions.mjs";
+import * as actions from "#cli/actions.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/test/cli/attributes-parser.spec.mts
+++ b/test/cli/attributes-parser.spec.mts
@@ -1,5 +1,5 @@
 import { deepEqual, equal } from "node:assert/strict";
-import { parse } from "../../src/cli/attributes-parser.mjs";
+import { parse } from "#cli/attributes-parser.mjs";
 
 function assertSyntaxError(pProgram, pParseFunction, pErrorType) {
   if (!pErrorType) {

--- a/test/cli/execute-command-line.spec.mts
+++ b/test/cli/execute-command-line.spec.mts
@@ -1,6 +1,6 @@
 import { Writable } from "node:stream";
 import { match } from "node:assert/strict";
-import executeCLI from "../../src/cli/execute-command-line.mjs";
+import executeCLI from "#cli/execute-command-line.mjs";
 
 class WritableTestStream extends Writable {
   expected: RegExp | RegExp[] = /^$/;

--- a/test/cli/file-name-to-stream.spec.mts
+++ b/test/cli/file-name-to-stream.spec.mts
@@ -2,10 +2,7 @@ import { fileURLToPath } from "node:url";
 import { ReadStream, WriteStream, unlinkSync } from "node:fs";
 import { Readable, Writable } from "node:stream";
 import { notStrictEqual, equal } from "node:assert/strict";
-import {
-  getInStream,
-  getOutStream,
-} from "../../src/cli/file-name-to-stream.mjs";
+import { getInStream, getOutStream } from "#cli/file-name-to-stream.mjs";
 
 const removeDammit = (pFileName) => {
   try {

--- a/test/cli/normalize.spec.mts
+++ b/test/cli/normalize.spec.mts
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import normalize from "../../src/cli/normalize.mjs";
+import normalize from "#cli/normalize.mjs";
 
 describe("#cli - normalize", () => {
   it("doesn't really know when presented with nothing", () => {

--- a/test/cli/validations.spec.mts
+++ b/test/cli/validations.spec.mts
@@ -1,5 +1,5 @@
 import { doesNotThrow, equal, throws } from "node:assert/strict";
-import validations from "../../src/cli/validations.mjs";
+import validations from "#cli/validations.mjs";
 
 describe("#cli - validate", () => {
   describe("output type", () => {

--- a/test/index.spec.mts
+++ b/test/index.spec.mts
@@ -1,9 +1,9 @@
 import { deepEqual, equal, throws } from "node:assert/strict";
 import fastxml from "fast-xml-parser";
-import smcat from "../src/index.mjs";
-import smcat_node from "../src/index-node.mjs";
-import options from "../src/options.mjs";
 import { createRequireJSON } from "./utl.mjs";
+import smcat from "#index.mjs";
+import smcat_node from "#index-node.mjs";
+import options from "#options.mjs";
 
 const $package = createRequireJSON(import.meta.url)("../package.json");
 const gXMLParser = new fastxml.XMLParser();

--- a/test/parse/scxml.spec.mts
+++ b/test/parse/scxml.spec.mts
@@ -4,8 +4,8 @@ import path from "node:path";
 import { deepEqual, doesNotThrow, throws } from "node:assert/strict";
 import Ajv from "ajv";
 
-import { parse } from "../../src/parse/scxml/index.mjs";
-import $schema from "../../src/parse/smcat-ast.schema.mjs";
+import { parse } from "#parse/scxml/index.mjs";
+import $schema from "#parse/smcat-ast.schema.mjs";
 
 const ajv = new Ajv();
 

--- a/test/parse/smcat-parser.spec.mts
+++ b/test/parse/smcat-parser.spec.mts
@@ -2,9 +2,9 @@ import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
 import { deepEqual, equal } from "node:assert/strict";
 import Ajv from "ajv";
-import { parse as parseSmCat } from "../../src/parse/smcat/smcat-parser.mjs";
-import $schema from "../../src/parse/smcat-ast.schema.mjs";
 import { createRequireJSON } from "../utl.mjs";
+import { parse as parseSmCat } from "#parse/smcat/smcat-parser.mjs";
+import $schema from "#parse/smcat-ast.schema.mjs";
 
 const ajv = new Ajv();
 

--- a/test/render/dot/attributebuilder.spec.mts
+++ b/test/render/dot/attributebuilder.spec.mts
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import attributebuilder from "../../../src/render/dot/attributebuilder.mjs";
+import attributebuilder from "#render/dot/attributebuilder.mjs";
 
 describe("attributebuilder ", () => {
   describe("buildGraphAttributes", () => {

--- a/test/render/dot/counter.spec.mts
+++ b/test/render/dot/counter.spec.mts
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import Counter from "../../../src/render/dot/counter.mjs";
+import Counter from "#render/dot/counter.mjs";
 
 describe("counter ", () => {
   it("starts as 0", () => {

--- a/test/render/dot/index.spec.mts
+++ b/test/render/dot/index.spec.mts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { equal } from "node:assert/strict";
-import convert from "../../../src/render/dot/index.mjs";
 import { createRequireJSON } from "../../utl.mjs";
+import convert from "#render/dot/index.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/render/dot/state-transformers.spec.mts
+++ b/test/render/dot/state-transformers.spec.mts
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import stateTransformers from "../../../src/render/dot/state-transformers.mjs";
+import stateTransformers from "#render/dot/state-transformers.mjs";
 
 describe("render/dot/state-transformers - classifyState ", () => {
   it("by default, states get 'state' and their type as a class attribute", () => {

--- a/test/render/dot/transition-transformers.spec.mts
+++ b/test/render/dot/transition-transformers.spec.mts
@@ -1,5 +1,5 @@
 import { deepEqual } from "node:assert/strict";
-import transitionTransformers from "../../../src/render/dot/transition-transformers.mjs";
+import transitionTransformers from "#render/dot/transition-transformers.mjs";
 
 describe("render/dot/transition-transformers - classifyState", () => {
   it("by default, transitions get 'transition' as a class attribute", () => {

--- a/test/render/dot/utl.spec.mts
+++ b/test/render/dot/utl.spec.mts
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
-import utl from "../../../src/render/dot/utl.mjs";
-import StateMachineModel from "../../../src/state-machine-model.mjs";
+import utl from "#render/dot/utl.mjs";
+import StateMachineModel from "#state-machine-model.mjs";
 
 const AST = {
   states: [

--- a/test/render/json.spec.mts
+++ b/test/render/json.spec.mts
@@ -3,9 +3,9 @@ import { readFileSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import { parse as convert } from "../../src/parse/smcat/smcat-parser.mjs";
+import { parse as convert } from "#parse/smcat/smcat-parser.mjs";
 
-import $schema from "../../src/parse/smcat-ast.schema.mjs";
+import $schema from "#parse/smcat-ast.schema.mjs";
 
 const ajv = new Ajv();
 

--- a/test/render/scjson/index.spec.mts
+++ b/test/render/scjson/index.spec.mts
@@ -3,8 +3,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
 import Ajv from "ajv";
-import convert from "../../../src/render/scjson/index.mjs";
 import $schema from "./scjson.schema.mjs";
+import convert from "#render/scjson/index.mjs";
 
 const ajv = new Ajv();
 

--- a/test/render/scjson/make-valid-event-names.spec.mts
+++ b/test/render/scjson/make-valid-event-names.spec.mts
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import makeValidEventNames from "../../../src/render/scjson/make-valid-event-names.mjs";
+import makeValidEventNames from "#render/scjson/make-valid-event-names.mjs";
 
 function checkExpectation(pExpectation, pValue) {
   const lValueToTest = makeValidEventNames(pValue);

--- a/test/render/scjson/make-valid-xml-name.spec.mts
+++ b/test/render/scjson/make-valid-xml-name.spec.mts
@@ -1,6 +1,6 @@
 import { equal } from "node:assert/strict";
 import XMLNameValidator from "xml-name-validator";
-import makeValidXMLName from "../../../src/render/scjson/make-valid-xml-name.mjs";
+import makeValidXMLName from "#render/scjson/make-valid-xml-name.mjs";
 
 function checkExpectationAndValidity(pExpectation, pValue) {
   const lValueToTest = makeValidXMLName(pValue);

--- a/test/render/scxml.spec.mts
+++ b/test/render/scxml.spec.mts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-import convert from "../../src/render/scxml/index.mjs";
+import convert from "#render/scxml/index.mjs";
 
 const FIXTURE_DIR = fileURLToPath(new URL("fixtures", import.meta.url));
 const FIXTURE_INPUTS = fs

--- a/test/render/smcat.spec.mts
+++ b/test/render/smcat.spec.mts
@@ -1,7 +1,7 @@
 import { deepEqual } from "node:assert/strict";
-import convert from "../../src/render/smcat/index.mjs";
-import { parse } from "../../src/parse/smcat/smcat-parser.mjs";
 import { createRequireJSON } from "../utl.mjs";
+import convert from "#render/smcat/index.mjs";
+import { parse } from "#parse/smcat/smcat-parser.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/render/vector/dot-to-vector-native.spec.mts
+++ b/test/render/vector/dot-to-vector-native.spec.mts
@@ -1,7 +1,7 @@
 import { equal, throws } from "node:assert/strict";
 import isPng from "is-png";
 import isPdf from "is-pdf";
-import dotToVector from "../../../src/render/vector/dot-to-vector-native.mjs";
+import dotToVector from "#render/vector/dot-to-vector-native.mjs";
 
 if (dotToVector.isAvailable()) {
   describe("dot-to-svg-native - isAvailable", () => {

--- a/test/render/vector/vector-native-dot-with-fallback.spec.mts
+++ b/test/render/vector/vector-native-dot-with-fallback.spec.mts
@@ -1,5 +1,5 @@
 import { equal, throws } from "node:assert/strict";
-import dotToSVG from "../../../src/render/vector/vector-native-dot-with-fallback.mjs";
+import dotToSVG from "#render/vector/vector-native-dot-with-fallback.mjs";
 
 const AST = {
   transitions: [

--- a/test/render/vector/vector-with-wasm.spec.mts
+++ b/test/render/vector/vector-with-wasm.spec.mts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { deepEqual } from "node:assert/strict";
-import convert from "../../../src/render/vector/vector-with-wasm.mjs";
+import convert from "#render/vector/vector-with-wasm.mjs";
 
 /**
  * GraphViz is not deterministic with clustering, so we're going to skip these

--- a/test/state-machine-model.spec.mts
+++ b/test/state-machine-model.spec.mts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import SMModel from "../src/state-machine-model.mjs";
 import { createRequireJSON } from "./utl.mjs";
+import SMModel from "#state-machine-model.mjs";
 
 const requireJSON = createRequireJSON(import.meta.url);
 

--- a/test/transform/desugar-forks.spec.mts
+++ b/test/transform/desugar-forks.spec.mts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
+import desugar from "#transform/desugar.mjs";
 
 describe("transform/desugar - forks", () => {
   it("replaces forks with the transitions they represent", () => {

--- a/test/transform/desugar-joins.spec.mts
+++ b/test/transform/desugar-joins.spec.mts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
+import desugar from "#transform/desugar.mjs";
 
 describe("transform/desugar - joins", () => {
   it("replaces joins with the transitions they represent", () => {

--- a/test/transform/desugar-junctions.spec.mts
+++ b/test/transform/desugar-junctions.spec.mts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
+import desugar from "#transform/desugar.mjs";
 
 describe("transform/desugar - junctions", () => {
   it("leaves empty state machines alone", () => {

--- a/test/transform/desugar.spec.mts
+++ b/test/transform/desugar.spec.mts
@@ -1,6 +1,6 @@
 import { deepEqual } from "node:assert/strict";
-import desugar from "../../src/transform/desugar.mjs";
 import utl from "./utl.mjs";
+import desugar from "#transform/desugar.mjs";
 
 describe("transform/desugar - forks", () => {
   it("leaves empty state machines alone", () => {


### PR DESCRIPTION
## Description

- uses subpath imports in tests

## Motivation and Context

Improves readability and maintainability.

## How Has This Been Tested?
- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
