### PR TITLE
chore(ci): uses node --run as task runner, instead of npm

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,7 @@ describe("my feature", () => {
 ## Parser Generation
 
 - Parser files are generated from `.peggy` grammar files in the `src/parse` directory
-- The build process (`npm run build`) handles parser generation using the Peggy parser generator
+- The build process (`node --run=build`) handles parser generation using the Peggy parser generator
 
 ## Type Declarations
 
@@ -104,13 +104,13 @@ import type { IStateMachine } from "#types/state-machine-cat.mjs";
 
 ```bash
 # Run tests
-npm test
+node --run=test
 
 # Run tests with coverage
-npm run test:cover
+node --run=test:cover
 
 # Build the project
-npm run build
+node --run=build
 ```
 
 When generating code, always:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,18 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
         if: github.event_name == 'pull_request' && matrix.node-version == env.NODE_LATEST
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
         if: github.event_name != 'pull_request' || matrix.node-version != env.NODE_LATEST
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{matrix.node-version}}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package-lock.json')}}
@@ -93,11 +93,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{env.NODE_LATEST}}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{matrix.node-version}}@${{matrix.platform}}-build-${{hashFiles('package-lock.json')}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,26 +52,26 @@ jobs:
       - name: lint (on node ${{env.NODE_LATEST}} only)
         if: matrix.node-version == env.NODE_LATEST
         run: |
-          npm run depcruise -- --progress performance-log --cache-strategy content
-          npm run lint
+          node --run=depcruise -- --progress performance-log --cache-strategy content
+          node --run=lint
       - name: test (on node != ${{env.NODE_LATEST}} only)
         if: matrix.node-version != env.NODE_LATEST
-        run: npm test
+        run: node --run=test
       - name: test coverage (on node ${{env.NODE_LATEST}} only)
         if: matrix.node-version == env.NODE_LATEST
-        run: npm run test:cover
+        run: node --run=test:cover
       - name: emit coverage results & depcruise result to step summary
         if: always() && matrix.node-version == env.NODE_LATEST
         run: |
           echo '## Code coverage' >> $GITHUB_STEP_SUMMARY
           npx tsx tools/istanbul-json-summary-to-markdown.mts < coverage/coverage-summary.json >> $GITHUB_STEP_SUMMARY
-          yarn --silent depcruise:github-actions:markdown --progress performance-log --cache-strategy content >> $GITHUB_STEP_SUMMARY
+          node --run=depcruise:github-actions:markdown -- --progress performance-log --cache-strategy content >> $GITHUB_STEP_SUMMARY
       - name: on pushes to the default branch emit graph to the step summary
         if: always() && matrix.node-version == env.NODE_LATEST && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
         run: |
           echo '## Visual overview' >> $GITHUB_STEP_SUMMARY
           echo '```mermaid' >> $GITHUB_STEP_SUMMARY
-          yarn --silent depcruise:github-actions:mermaid --progress performance-log --cache-strategy content >> $GITHUB_STEP_SUMMARY
+          node --run=depcruise:github-actions:mermaid -- --progress performance-log --cache-strategy content >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: on pull requests emit depcruise graph to step summary with changed modules highlighted
@@ -80,7 +80,7 @@ jobs:
           echo '## Visual diff' >> $GITHUB_STEP_SUMMARY
           echo Modules changed in this PR have a fluorescent green color. All other modules in the graph are those directly or indirectly affected by changes in the green modules. >> $GITHUB_STEP_SUMMARY
           echo '```mermaid' >> $GITHUB_STEP_SUMMARY
-          SHA=${{github.event.pull_request.base.sha}} yarn --silent depcruise:github-actions:mermaid:affected --progress performance-log >> $GITHUB_STEP_SUMMARY
+          SHA=${{github.event.pull_request.base.sha}} node --run=depcruise:github-actions:mermaid:affected -- --progress performance-log >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: dependency review (manifest scan)
@@ -104,4 +104,4 @@ jobs:
           restore-keys: |
             ${{matrix.node-version}}@${{matrix.platform}}-build-
       - run: npm install
-      - run: npm test
+      - run: node --run=test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_LATEST: 24.x
+  NODE_LATEST: 25.x
   CI: true
 
 defaults:
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 24.x]
+        node-version: [22.x, 25.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,9 +37,9 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v4
         with:
           languages: javascript
           config-file: ./.github/codeql/codeql-config.yml
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,9 @@ test_async_node:
   image: node:latest
   script:
     - npm install
-    - npm run depcruise
-    - npm run lint
-    - npm run test:cover
+    - node --run=depcruise
+    - node --run=lint
+    - node --run=test:cover
   except:
     - tags
 
@@ -18,7 +18,7 @@ pages:
   image: node:latest
   script:
     - npm install
-    - npm run build
+    - node --run=build
   artifacts:
     paths:
       - public

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A no-frills interpreter on line: [state-machine-cat.js.org](https://state-machin
 
 ### Command line interface
 
-Just `npm install --global state-machine-cat` and run `smcat`
+`npm install --global state-machine-cat` and run `smcat`
 
 This is what `smcat --help` would get you:
 

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -61,7 +61,7 @@ window.YOURRENDERER.addEventListener("click", updateViewModel('outputType'), fal
 ...
 ```
 
-- `npm run build` to build the site (esbuild to prod; `docs/index.hbs`
+- `node --run=build` to build the site (esbuild to prod; `docs/index.hbs`
   -> `docs/index.html`).
 - To test start a simple webserver in the `docs` folder (e.g. with
   `python -m SimpleHTTPServer 8481`) and open your webbrowser on http://localhost:8481

--- a/tools/regenerate_render_fixtures.sh
+++ b/tools/regenerate_render_fixtures.sh
@@ -66,6 +66,6 @@ dist/cli/main.mjs -T json test/parse/fixtures/states-with-a-label.smcat
 
 
 echo "6/6 formatting results ..."
-npm run format
+node --run=format
 
 echo "done"


### PR DESCRIPTION
## Description

- uses node --run as task runner, instead of npm
- 🏕️ bumps actions to latest

## Motivation and Context

Probably a tad faster. Easier to switch to a different package manager might the need arise.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Chore (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
