### PR TITLE
fix(render): pass the engine option to the native graphviz executable

### DIFF
--- a/src/render/vector/dot-to-vector-native.mts
+++ b/src/render/vector/dot-to-vector-native.mts
@@ -1,15 +1,17 @@
 import { spawnSync } from "node:child_process";
-import type { OutputType } from "#types/state-machine-cat.mjs";
+import type { EngineType, OutputType } from "#types/state-machine-cat.mjs";
 
 // eslint-disable-next-line import/exports-last
 export type DotToVectorNativeOptionsType = {
   exec: string;
   format: OutputType;
+  engine: EngineType;
 };
 
 const DEFAULT_OPTIONS: DotToVectorNativeOptionsType = {
   exec: "dot",
   format: "svg",
+  engine: "dot",
 };
 
 /**
@@ -32,7 +34,7 @@ export function convert(
   };
   const { stdout, status, error } = spawnSync(
     lOptions.exec,
-    [`-T${lOptions.format}`],
+    [`-K${lOptions.engine}`, `-T${lOptions.format}`],
     {
       // cwd: lOptions.workingDirectory,
       input: pDot,

--- a/src/render/vector/vector-native-dot-with-fallback.mts
+++ b/src/render/vector/vector-native-dot-with-fallback.mts
@@ -7,6 +7,7 @@ import {
   convert,
 } from "./dot-to-vector-native.mjs";
 import type {
+  EngineType,
   IRenderOptions,
   OutputType,
   StringRenderFunctionType,
@@ -18,7 +19,7 @@ const gGraphViz = await Graphviz.load();
 const renderVector: StringRenderFunctionType = (pStateMachine, pOptions) => {
   const lDotProgram = ast2dot(pStateMachine, pOptions);
   const lDotOptions = {
-    engine: getOptionValue(pOptions as IRenderOptions, "engine") as string,
+    engine: getOptionValue(pOptions as IRenderOptions, "engine") as EngineType,
     format: getOptionValue(
       pOptions as IRenderOptions,
       "outputType",

--- a/test/render/vector/dot-to-vector-native.spec.mts
+++ b/test/render/vector/dot-to-vector-native.spec.mts
@@ -78,6 +78,20 @@ if (isAvailable({})) {
       equal(isPdf(lFoundAsBuffer), true);
     });
 
+    it("passes the engine to graphviz (dot and circo yield different layouts)", () => {
+      const lTriangle = "digraph { a -> b -> c -> a }";
+      const lDot = convert(lTriangle, { engine: "dot" });
+      const lCirco = convert(lTriangle, { engine: "circo" });
+
+      equal(lDot === lCirco, false);
+    });
+
+    it("defaults to the dot engine when no engine is passed", () => {
+      const lTriangle = "digraph { a -> b -> c -> a }";
+
+      equal(convert(lTriangle), convert(lTriangle, { engine: "dot" }));
+    });
+
     it("throws an error when presented with an invalid dot", () => {
       throws(() => {
         convert("this ain't no dot program");


### PR DESCRIPTION
## Description

When the native GraphViz `dot` executable is on the PATH, `-E`/`--engine` (api: `engine`) is silently ignored for all the vector output types (`svg`, `png`, `pdf`, `ps`, `ps2`, `eps`). Every engine renders as if `dot` had been selected.

`vector-native-dot-with-fallback.mts` resolves the option and passes it down in `lDotOptions.engine`, but `dot-to-vector-native.mts`'s `convert()` had no `engine` member on its options type and spawned:

```
spawnSync(lOptions.exec, [`-T${lOptions.format}`], ...)
```

— so the value was quietly dropped on the floor. This adds `engine` to `DotToVectorNativeOptionsType` (defaulting to `dot`) and passes `-K${engine}`.

The wasm fallback path *does* honour the engine (it passes it to `gGraphViz.layout()`), so this only affects users who have GraphViz installed — which is the recommended setup, and the one where `--engine` looks most like it ought to work.

## Motivation and Context

`--engine circo` (or `fdp`/`neato`/`osage`/`twopi`) currently has no effect for anyone with GraphViz installed, with no error or warning to indicate why.

## How Has This Been Tested?

Two unit tests in `test/render/vector/dot-to-vector-native.spec.mts`: one asserting `dot` and `circo` layouts of a triangle differ, one asserting the default is still `dot`.

End-to-end, rendering the same source with three engines — before, `circo` and `twopi` are byte-identical (both silently fell back to `dot`):

```
before                          after
dot   43dbf032...               dot   43dbf032...
circo 5f3d283b...  | identical  circo 6b709b4f...
twopi 5f3d283b...  |            twopi e4883948...
```

`node --run=test`: 1073 passing, 2 pending. One pre-existing failure (`fileNameToStream > getInStream('-') does not yield a file stream`) also fails on an unmodified `main` in my environment — it looks TTY/stdin dependent and is unrelated to this change.

Environment: node v24, macOS 15, GraphViz 15.1.0.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update — the option is already documented, it just didn't work.

- [x] :balance_scale:
  - The contribution will be subject to The MIT license, and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in CONTRIBUTING.md.
