### PR TITLE
fix: write text output as utf8 instead of latin1

### DIFF
--- a/src/cli/actions.mts
+++ b/src/cli/actions.mts
@@ -33,6 +33,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const MAX_INPUT_BYTES = 4_194_304; // 4Mb
 const ONE_MEGA_BYTE = 1_048_576;
+// Output types graphviz emits as binary. For these the render result is a
+// latin1 ('binary') string of raw bytes, which has to be written back out as
+// such. Everything else is text, and writing it as latin1 mangles any
+// non-ASCII in it (an em dash would end up as a single 0x14 byte).
+const BINARY_OUTPUT_TYPES: Set<string> = new Set(["png", "pdf"]);
 
 function getStream(pStream: Readable): Promise<string> {
   return new Promise((pResolve, pReject) => {
@@ -81,7 +86,7 @@ export function transform(
       typeof lOutput === "string"
         ? lOutput
         : JSON.stringify(lOutput, null, "    "),
-      "binary",
+      BINARY_OUTPUT_TYPES.has(pOptions.outputType) ? "binary" : "utf8",
     );
   });
 }

--- a/src/render/vector/dot-to-vector-native.mts
+++ b/src/render/vector/dot-to-vector-native.mts
@@ -11,6 +11,11 @@ const DEFAULT_OPTIONS: DotToVectorNativeOptionsType = {
   exec: "dot",
   format: "svg",
 };
+// Formats graphviz emits as binary. These get returned as latin1 ('binary')
+// strings, so callers can Buffer.from(result, "binary") to get the bytes back.
+// The text formats get decoded as utf8 - decoding them as latin1 mangles any
+// non-ASCII the diagram contains.
+const BINARY_FORMATS: Set<string> = new Set(["png", "pdf"]);
 
 /**
  * Takes a graphviz dot program (as a string), runs it through the dot
@@ -43,7 +48,9 @@ export function convert(
   //  1: error in the program
   // -2: executable not found
   if (status === 0) {
-    return stdout.toString("binary");
+    return stdout.toString(
+      BINARY_FORMATS.has(lOptions.format) ? "binary" : "utf8",
+    );
   } else if (error) {
     // @ts-expect-error we should probably use error.message here
     throw new Error(error);

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -1,4 +1,10 @@
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { equal, rejects } from "node:assert/strict";
@@ -56,6 +62,23 @@ const testPairs = [
   pTestPair.expected = join(__dirname, pTestPair.expected);
   return pTestPair;
 });
+
+async function readWhenWritten(
+  pFileName: string,
+  pAttemptsLeft = 100,
+): Promise<string> {
+  if (existsSync(pFileName)) {
+    const lContents = readFileSync(pFileName, "utf8");
+    if (lContents.length > 0) {
+      return lContents;
+    }
+  }
+  if (pAttemptsLeft <= 0) {
+    throw new Error(`${pFileName} never got written`);
+  }
+  await new Promise((pResolve) => setTimeout(pResolve, 10));
+  return readWhenWritten(pFileName, pAttemptsLeft - 1);
+}
 
 function resetOutputDirectory(): void {
   for (const lPair of testPairs) {
@@ -127,6 +150,39 @@ describe("#cli - actions", () => {
         // oxlint-disable-next-line no-unused-vars
       } catch (pError_) {
         // ignore
+      }
+    });
+
+    it("writes non-ASCII to text output as utf8", async () => {
+      const lInput = join(__dirname, "output", "non-ascii.smcat");
+      const lOutput = join(__dirname, "output", "non-ascii.dot");
+      try {
+        mkdirSync(dirname(lInput), { recursive: true });
+        // oxlint-disable-next-line no-unused-vars
+      } catch (pError_) {
+        // ignore
+      }
+      writeFileSync(lInput, "a => b : em—dash · 👤;\n", "utf8");
+
+      await actions.transform({
+        inputFrom: lInput,
+        inputType: "smcat",
+        outputTo: lOutput,
+        outputType: "dot",
+      } as ICLIRenderOptions);
+
+      // transform resolves as soon as it's handed the output to the write
+      // stream, which is before that stream has flushed to disk - hence the
+      // wait before reading the result back.
+      equal((await readWhenWritten(lOutput)).includes("em—dash · 👤"), true);
+
+      for (const lFileName of [lInput, lOutput]) {
+        try {
+          unlinkSync(lFileName);
+          // oxlint-disable-next-line no-unused-vars
+        } catch (pError_) {
+          // ignore
+        }
       }
     });
   });

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -86,9 +86,8 @@ function resetOutputDirectory(): void {
       if (lPair.input.options.outputTo) {
         unlinkSync(lPair.input.options.outputTo);
       }
-      // oxlint-disable-next-line no-unused-vars
-    } catch (pError) {
-} catch {
+    } catch {
+      // probably files didn't exist in the first place
       // so ignore the exception
     }
   }

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -158,8 +158,7 @@ describe("#cli - actions", () => {
       const lOutput = join(__dirname, "output", "non-ascii.dot");
       try {
         mkdirSync(dirname(lInput), { recursive: true });
-        // oxlint-disable-next-line no-unused-vars
-      } catch (pError_) {
+      } catch {
         // ignore
       }
       writeFileSync(lInput, "a => b : em—dash · 👤;\n", "utf8");

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -179,8 +179,7 @@ describe("#cli - actions", () => {
       for (const lFileName of [lInput, lOutput]) {
         try {
           unlinkSync(lFileName);
-          // oxlint-disable-next-line no-unused-vars
-        } catch (pError_) {
+        } catch {
           // ignore
         }
       }

--- a/test/cli/actions.spec.mts
+++ b/test/cli/actions.spec.mts
@@ -88,7 +88,7 @@ function resetOutputDirectory(): void {
       }
       // oxlint-disable-next-line no-unused-vars
     } catch (pError) {
-      // probably files didn't exist in the first place
+} catch {
       // so ignore the exception
     }
   }

--- a/test/render/vector/dot-to-vector-native.spec.mts
+++ b/test/render/vector/dot-to-vector-native.spec.mts
@@ -78,6 +78,12 @@ if (isAvailable({})) {
       equal(isPdf(lFoundAsBuffer), true);
     });
 
+    it("returns non-ASCII in text output undamaged", () => {
+      const lFound = convert('digraph { a [label="em—dash · 👤"] }');
+
+      equal(lFound.includes("em—dash · 👤"), true);
+    });
+
     it("throws an error when presented with an invalid dot", () => {
       throws(() => {
         convert("this ain't no dot program");


### PR DESCRIPTION
## Description

Non-ASCII characters in labels come out corrupted in every text output format. An em dash (`e2 80 94`) becomes a single `0x14` byte; an emoji (`f0 9f 91 a4`) becomes `=d`.

For `-T dot` that's cosmetic, but for `-T svg` it's worse than that: GraphViz rejects the malformed node with `not well-formed (invalid token)` and the state silently disappears from the rendered diagram.

Two places assumed everything GraphViz touches is binary:

- `src/cli/actions.mts` wrote every render result to the output stream as latin1 (`"binary"`)
- `src/render/vector/dot-to-vector-native.mts` decoded GraphViz' stdout as latin1

`png` and `pdf` genuinely are binary and stay on `"binary"`, so callers can still `Buffer.from(result, "binary")` to recover the bytes (which the existing png/pdf tests rely on). Everything else is now utf8.

Worth flagging for review: **these two had to change together.** For svg the two bugs cancelled out — a mojibake string went in, the latin1 write turned it back into the right bytes on disk — so fixing either one alone regresses svg. That's also why this isn't split into two commits.

## Motivation and Context

Any diagram with a non-ASCII character in a label is affected. In the svg case the failure is silent and destructive: a whole state vanishes with no error on stdout or stderr.

Steps taken / expected / found:

```
$ printf 'a => b : em—dash · 👤;\n' > nonascii.smcat
$ smcat -I smcat -T dot nonascii.smcat -o -
```

- expected: the label round-trips
- found: `R-PR \x14 open draft PR  =d RM` (the API, called directly, returns the correct bytes — it's the CLI write and the native converter's decode that mangle them)

## How Has This Been Tested?

- unit test in `test/render/vector/dot-to-vector-native.spec.mts` asserting non-ASCII survives `convert()` for a text format
- end-to-end test in `test/cli/actions.spec.mts` writing a label with an em dash, a middle dot and an emoji through `transform()` to a file and reading it back

Both fail without the change and pass with it. I checked all five output paths at the byte level after the fix: `dot`, `svg` and `json` keep `e2 80 94` / `f0 9f 91 a4` intact; `png` still starts with `89 50 4e 47 0d 0a 1a 0a` and `pdf` with `%PDF-`.

`node --run=test`: 1073 passing, 2 pending. One pre-existing failure (`fileNameToStream > getInStream('-') does not yield a file stream`) also fails on an unmodified `main` in my environment — it looks TTY/stdin dependent and is unrelated to this change.

Environment: node v24, macOS 15, GraphViz 15.1.0.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update — it makes documented behaviour work.

- [x] :balance_scale:
  - The contribution will be subject to The MIT license, and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in CONTRIBUTING.md.
