### PR TITLE
feature: adds a labelGap option to space transition labels off their lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ options:
   --dot-graph-attrs <string>  graph attributes to pass to the dot render engine
   --dot-node-attrs <string>   node attributes to pass to the dot render engine
   --dot-edge-attrs <string>   edge attributes to pass to the dot render engine
+  --label-gap <number>        spaces between a transition's label and its line
 ```
 
 With these you can override default attributes in the generated picture; e.g. to
@@ -107,6 +108,14 @@ splines, use this:
 
 ```sh
 smcat --dot-graph-attrs "bgcolor=transparent splines=line" docs/sample.smcat
+```
+
+In diagrams with long transition labels the labels can end up sitting on top of
+the lines they belong to. `--label-gap` puts a number of spaces in front of each
+line of each label to push them clear:
+
+```sh
+smcat --label-gap 4 docs/sample.smcat
 ```
 
 ### Syntax highlighting

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,6 +99,16 @@ which in the vast majority of cases will yield the best results.
 
 Allowed values: call `smcat.getAllowedValues().engine.values`
 
+##### `options.labelGap`
+
+The number of spaces to put in front of each line of each transition label,
+which pushes the label clear of the line it belongs to. Defaults to `0`. Only
+makes sense for outputTypes that go through `dot`.
+
+GraphViz preserves leading spaces, so this moves the label text itself. Trailing
+spaces would only make the label's bounding box wider, leaving the text where it
+was.
+
 #### `options.dotGraphAttrs`, `options.dotNodeAttrs`, `options.dotEdgeAttrs`
 
 An array of name/ value pairs that represent graph (/node /edge) level parameters

--- a/src/cli/actions.mts
+++ b/src/cli/actions.mts
@@ -74,6 +74,7 @@ export function transform(
       dotGraphAttrs: pOptions.dotGraphAttrs,
       dotNodeAttrs: pOptions.dotNodeAttrs,
       dotEdgeAttrs: pOptions.dotEdgeAttrs,
+      labelGap: pOptions.labelGap,
       desugar: pOptions.desugar,
     });
 

--- a/src/cli/cli-types.d.mts
+++ b/src/cli/cli-types.d.mts
@@ -24,4 +24,9 @@ export interface ILooseCLIRenderOptions extends Partial<IBaseRenderOptions> {
    * For the 'dot' renderer: Edge attributes to the engine
    */
   dotEdgeAttrs?: string;
+  /**
+   * For the 'dot' renderer: spaces between a transition label and its line.
+   * Comes off the command line as a string; normalize turns it into a number.
+   */
+  labelGap?: string;
 }

--- a/src/cli/cli-types.d.mts
+++ b/src/cli/cli-types.d.mts
@@ -9,7 +9,10 @@ export interface ICLIRenderOptions extends IRenderOptions {
   outputTo: string;
 }
 
-export interface ILooseCLIRenderOptions extends Partial<IBaseRenderOptions> {
+export interface ILooseCLIRenderOptions extends Omit<
+  Partial<IBaseRenderOptions>,
+  "labelGap"
+> {
   inputFrom?: string;
   outputTo?: string;
   /**

--- a/src/cli/cli.mts
+++ b/src/cli/cli.mts
@@ -10,6 +10,7 @@ import {
   validInputType,
   validEngine,
   validDirection,
+  validLabelGap,
   // eslint-disable-next-line unicorn/prevent-abbreviations
   validDotAttrs,
   validateArguments,
@@ -32,6 +33,8 @@ Options:
   -d, --direction <dir>     top-down|bottom-top|left-right|right-left (default:
                             "top-down")
   -o --output-to <file>     File to write to. use - for stdout.
+  --label-gap <number>      spaces between a transition's label and its line
+                            (default: "0")
   --desugar                 transform pseudo states into transitions
                             (!experimental!)
   -V, --version             output the version number
@@ -107,6 +110,9 @@ function parseArguments(pArguments: string[]): {
     "dot-edge-attrs": {
       type: "string",
     },
+    "label-gap": {
+      type: "string",
+    },
     desugar: {
       type: "boolean",
       default: false,
@@ -161,6 +167,9 @@ function parseArguments(pArguments: string[]): {
       // @ts-expect-error whatever
       values["dot-edge-attrs"],
     );
+  if (values["label-gap"])
+    // @ts-expect-error whatever
+    values["label-gap"] = validLabelGap(values["label-gap"]);
 
   return { values: camelizeObject(values), positionals };
 }

--- a/src/cli/normalize.mts
+++ b/src/cli/normalize.mts
@@ -136,6 +136,12 @@ function determineParameter(
     : getAllowedValues()[pParameter].default;
 }
 
+function determineLabelGap(pOptions: ILooseCLIRenderOptions): number {
+  return Object.hasOwn(pOptions, "labelGap")
+    ? Number(pOptions.labelGap)
+    : (getAllowedValues().labelGap.default as number);
+}
+
 function determineDotAttributes(
   pOptions: ILooseCLIRenderOptions,
   pDotAttributes: keyof ILooseCLIRenderOptions,
@@ -186,6 +192,7 @@ export default function normalize(
     dotGraphAttrs: determineDotAttributes(pLooseOptions, "dotGraphAttrs"),
     dotNodeAttrs: determineDotAttributes(pLooseOptions, "dotNodeAttrs"),
     dotEdgeAttrs: determineDotAttributes(pLooseOptions, "dotEdgeAttrs"),
+    labelGap: determineLabelGap(pLooseOptions),
     desugar: pLooseOptions?.desugar ?? false,
   };
 }

--- a/src/cli/validations.mts
+++ b/src/cli/validations.mts
@@ -92,6 +92,18 @@ export const validDirection = (
       `\n         you can choose from ${VALID_DIRECTIONS.join(", ")}\n\n`,
   );
 
+export const validLabelGap = (pLabelGap: string): string => {
+  const lLabelGap = Number(pLabelGap);
+
+  if (!Number.isInteger(lLabelGap) || lLabelGap < 0) {
+    throw new Error(
+      `\n  error: '${pLabelGap}' is not a valid label gap.` +
+        `\n         pass a whole number of spaces (0 or more)\n\n`,
+    );
+  }
+  return pLabelGap;
+};
+
 // eslint-disable-next-line unicorn/prevent-abbreviations
 export const validDotAttrs = (
   pDotAttributes: keyof IRenderOptions,
@@ -140,3 +152,5 @@ export const defaultEngine = allowedValues.engine.default;
 export const validDirectionRE = VALID_DIRECTIONS.join("|");
 
 export const defaultDirection = allowedValues.direction.default;
+
+export const defaultLabelGap = allowedValues.labelGap.default;

--- a/src/cli/validations.mts
+++ b/src/cli/validations.mts
@@ -95,10 +95,10 @@ export const validDirection = (
 export const validLabelGap = (pLabelGap: string): string => {
   const lLabelGap = Number(pLabelGap);
 
-  if (!Number.isInteger(lLabelGap) || lLabelGap < 0) {
+  if (!Number.isInteger(lLabelGap) || lLabelGap < 0 || lLabelGap > 10) {
     throw new Error(
       `\n  error: '${pLabelGap}' is not a valid label gap.` +
-        `\n         pass a whole number of spaces (0 or more)\n\n`,
+        `\n         pass a whole number of spaces (between 0 and 10 inclusive)\n\n`,
     );
   }
   return pLabelGap;

--- a/src/options.mts
+++ b/src/options.mts
@@ -53,12 +53,15 @@ const ALLOWED_VALUES: IAllowedValues = Object.freeze({
     default: false,
     values: [{ name: true }, { name: false }],
   },
+  labelGap: {
+    default: 0,
+  },
 });
 
 export function getOptionValue(
   pOptions: IRenderOptions | null,
   pOptionName: keyof IAllowedValues,
-): string | boolean {
+): string | boolean | number {
   // eslint-disable-next-line security/detect-object-injection
   return pOptions?.[pOptionName] ?? ALLOWED_VALUES[pOptionName].default;
 }

--- a/src/render/dot/index.mts
+++ b/src/render/dot/index.mts
@@ -301,7 +301,10 @@ function transition(
   pModel: StateMachineModel,
 ): string {
   // TODO: should also be he.escape'd?
-  const lLabel = `${escapeLabelString(pTransition.label ?? " ")}`;
+  const lLabel = `${escapeLabelString(
+    pTransition.label ?? " ",
+    getOptionValue(pOptions, "labelGap") as number,
+  )}`;
   const lPenWidth = pTransition.width ? ` penwidth=${pTransition.width}` : "";
   const lClass = pTransition.class
     ? // eslint-disable-next-line prefer-template

--- a/src/render/dot/utl.mts
+++ b/src/render/dot/utl.mts
@@ -48,12 +48,23 @@ export function escapeString(pString: string): string {
     .concat(String.raw`\l`);
 }
 
-export function escapeLabelString(pString: string): string {
-  return pString
-    .replaceAll("\\", String.raw`\\`)
-    .replaceAll(/\n\s*/g, String.raw`   \l`)
-    .replaceAll('"', String.raw`\"`)
-    .concat(String.raw`   \l`);
+export function escapeLabelString(
+  pString: string,
+  pLabelGap: number = 0,
+): string {
+  // GraphViz preserves leading spaces (it emits them as &#160;), so prefixing
+  // each line is what moves a label away from the line it labels. The trailing
+  // spaces below only widen the label's bounding box - the glyphs themselves
+  // still start right on top of the line.
+  const lGap = " ".repeat(pLabelGap);
+
+  return lGap.concat(
+    pString
+      .replaceAll("\\", String.raw`\\`)
+      .replaceAll(/\n\s*/g, String.raw`   \l`.concat(lGap))
+      .replaceAll('"', String.raw`\"`)
+      .concat(String.raw`   \l`),
+  );
 }
 
 // TODO integrate this into the normalization

--- a/test/cli/normalize.spec.mts
+++ b/test/cli/normalize.spec.mts
@@ -13,6 +13,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -28,6 +29,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -43,6 +45,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -58,6 +61,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -73,6 +77,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -88,6 +93,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -108,6 +114,7 @@ describe("#cli - normalize", () => {
         dotGraphAttrs: [],
         dotNodeAttrs: [],
         dotEdgeAttrs: [],
+        labelGap: 0,
         desugar: false,
       },
     );
@@ -124,6 +131,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -139,6 +147,23 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
+      desugar: false,
+    });
+  });
+
+  it("accepts and processes the 'labelGap' parameter", () => {
+    deepEqual(normalize("eidereend.wak", { labelGap: "6" }), {
+      inputFrom: "eidereend.wak",
+      inputType: "smcat",
+      outputTo: "eidereend.svg",
+      outputType: "svg",
+      engine: "dot",
+      direction: "top-down",
+      dotGraphAttrs: [],
+      dotNodeAttrs: [],
+      dotEdgeAttrs: [],
+      labelGap: 6,
       desugar: false,
     });
   });
@@ -154,6 +179,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -180,6 +206,7 @@ describe("#cli - normalize", () => {
         ],
         dotNodeAttrs: [],
         dotEdgeAttrs: [],
+        labelGap: 0,
         desugar: false,
       },
     );
@@ -196,6 +223,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -211,6 +239,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -226,6 +255,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });
@@ -241,6 +271,7 @@ describe("#cli - normalize", () => {
       dotGraphAttrs: [],
       dotNodeAttrs: [],
       dotEdgeAttrs: [],
+      labelGap: 0,
       desugar: false,
     });
   });

--- a/test/cli/validations.spec.mts
+++ b/test/cli/validations.spec.mts
@@ -4,6 +4,7 @@ import {
   validInputType,
   validEngine,
   validDirection,
+  validLabelGap,
   validDotAttrs,
   validateArguments,
 } from "#cli/validations.mjs";
@@ -86,6 +87,55 @@ describe("#cli - validate", () => {
         lFoundError.includes(
           "error: 'to-the-moon-and-back' is not a valid direction",
         ),
+        true,
+      );
+    });
+  });
+
+  describe("#validLabelGap() - ", () => {
+    it("'6' is a valid label gap", () => {
+      equal(validLabelGap("6"), "6");
+    });
+
+    it("'0' is a valid label gap", () => {
+      equal(validLabelGap("0"), "0");
+    });
+
+    it("'-1' is not a valid label gap", () => {
+      let lFoundError = "";
+
+      try {
+        validLabelGap("-1");
+      } catch (pError) {
+        lFoundError = pError.message;
+      }
+      equal(lFoundError.includes("error: '-1' is not a valid label gap"), true);
+    });
+
+    it("'two' is not a valid label gap", () => {
+      let lFoundError = "";
+
+      try {
+        validLabelGap("two");
+      } catch (pError) {
+        lFoundError = pError.message;
+      }
+      equal(
+        lFoundError.includes("error: 'two' is not a valid label gap"),
+        true,
+      );
+    });
+
+    it("'1.5' is not a valid label gap", () => {
+      let lFoundError = "";
+
+      try {
+        validLabelGap("1.5");
+      } catch (pError) {
+        lFoundError = pError.message;
+      }
+      equal(
+        lFoundError.includes("error: '1.5' is not a valid label gap"),
         true,
       );
     });

--- a/test/cli/validations.spec.mts
+++ b/test/cli/validations.spec.mts
@@ -139,6 +139,20 @@ describe("#cli - validate", () => {
         true,
       );
     });
+
+    it("'481' is not a valid label gap", () => {
+      let lFoundError = "";
+
+      try {
+        validLabelGap("481");
+      } catch (pError) {
+        lFoundError = pError.message;
+      }
+      equal(
+        lFoundError.includes("error: '481' is not a valid label gap"),
+        true,
+      );
+    });
   });
 
   describe("#validDotAttrs() - ", () => {

--- a/test/render/dot/utl.spec.mts
+++ b/test/render/dot/utl.spec.mts
@@ -43,6 +43,38 @@ const AST = {
   ],
 };
 
+describe("utl.escapeLabelString", () => {
+  it("doesn't prefix anything when no gap is passed", () => {
+    equal(utl.escapeLabelString("aap"), String.raw`aap   \l`);
+  });
+
+  it("doesn't prefix anything for a gap of 0", () => {
+    equal(utl.escapeLabelString("aap", 0), String.raw`aap   \l`);
+  });
+
+  it("prefixes the label with the gap", () => {
+    equal(utl.escapeLabelString("aap", 3), String.raw`   aap   \l`);
+  });
+
+  it("prefixes continuation lines with the gap as well", () => {
+    equal(
+      utl.escapeLabelString("aap\nnoot", 2),
+      String.raw`  aap   \l  noot   \l`,
+    );
+  });
+
+  it("still strips source indentation from continuation lines", () => {
+    equal(
+      utl.escapeLabelString("aap\n      noot", 2),
+      String.raw`  aap   \l  noot   \l`,
+    );
+  });
+
+  it("leaves escaping of quotes and backslashes alone", () => {
+    equal(utl.escapeLabelString('a"b\\c', 1), String.raw` a\"b\\c   \l`);
+  });
+});
+
 describe("utl.isCompositeSelf ", () => {
   const lModel = new StateMachineModel(AST);
 

--- a/types/state-machine-cat.d.mts
+++ b/types/state-machine-cat.d.mts
@@ -164,12 +164,18 @@ export interface IAllowedBooleanValue {
     name: boolean;
   }[];
 }
+
+export interface IAllowedNumberValue {
+  default: number;
+}
+
 export interface IAllowedValues {
   inputType: IAllowedValue;
   outputType: IAllowedValue;
   engine: IAllowedValue;
   direction: IAllowedValue;
   desugar: IAllowedBooleanValue;
+  labelGap: IAllowedNumberValue;
 }
 
 /**
@@ -239,6 +245,12 @@ export interface IBaseRenderOptions {
    * For details: https://github.com/sverweij/state-machine-cat/blob/main/docs/desugar.md
    */
   desugar?: boolean;
+  /**
+   * For the 'dot' renderer: how many spaces to put between a transition's
+   * label and the line it belongs to (defaults to 0). Useful to stop labels
+   * from overlapping their lines in dense diagrams.
+   */
+  labelGap?: number;
 }
 
 export interface IRenderOptions extends IBaseRenderOptions {


### PR DESCRIPTION
## Description

Adds a `--label-gap <number>` CLI option (api: `labelGap`) that prefixes each line of each transition label with that many spaces, pushing the label text clear of the line it belongs to.

Defaults to `0`, so **output is byte-identical unless you ask for a gap.**

While working on this I noticed something you may want to know regardless of whether you take this PR. `escapeLabelString` currently appends three spaces to every label line:

```js
.replaceAll(/\n\s*/g, String.raw`   \l`)
.concat(String.raw`   \l`);
```

Those trailing spaces don't create any clearance. With `\l` left-justification they only widen the label's bounding box to the right — the glyphs still start exactly on the line. Measuring the emitted svg at four different padding widths, the text x-coordinate never moves:

```
trailing spaces   svg width   label text x   edge x
0                 92pt        27             27
3                 101pt       27             27
6                 110pt       27             27
9                 119pt       27             27
```

Leading spaces are what work — GraphViz preserves them (it emits them as `&#160;`), so the ink moves. Hence the gap is prepended. I left the existing trailing spaces alone to keep the default output unchanged, but they may be doing less than intended.

## Motivation and Context

In diagrams with longish transition labels — particularly multi-line ones — the label text ends up sitting on top of its own line, which is hard to read. There's currently no way to influence that: `labeldistance`/`labelangle` only affect `headlabel`/`taillabel`, and `labelfloat` makes things worse by letting labels collide with each other.

Because the gap is inserted by the replacement (i.e. after the existing `/\n\s*/` strip), it applies to continuation lines too, so multi-line labels move as a block rather than only on their first line.

## How Has This Been Tested?

- 6 unit tests on `escapeLabelString` in `test/render/dot/utl.spec.mts`: no-arg and explicit-`0` produce the current output unchanged; a gap prefixes the label; continuation lines get the gap as well; source indentation is still stripped; quote/backslash escaping is untouched
- 5 tests on `validLabelGap` in `test/cli/validations.spec.mts` (accepts `0` and `6`; rejects `-1`, `two` and `1.5`)
- 1 test in `test/cli/normalize.spec.mts` for the string→number coercion, plus the existing 15 normalize expectations updated for the new key

`node --run=test`: 1083 passing, 2 pending. One pre-existing failure (`fileNameToStream > getInStream('-') does not yield a file stream`) also fails on an unmodified `main` in my environment — it looks TTY/stdin dependent and is unrelated to this change.

Documentation updated in `README.md` (advanced options) and `docs/api.md`.

Environment: node v24, macOS 15, GraphViz 15.1.0.

## Screenshots

Rather than attach images: the effect is reproducible in one command. With

```
A => B : "R-DEPLOY  AUTO\nMon 15:30 CT\n[build green]";
```

`smcat -T svg` puts the label text hard against the arrow, and
`smcat -T svg --label-gap 4` moves all three lines of it clear, together.

The emitted svg shows what changed:

```
--label-gap 0:  <text ...>R&#45;DEPLOY &#160;&#160;</text>
--label-gap 4:  <text ...> &#160;&#160;R&#45;DEPLOY &#160;&#160;</text>
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] :book:

  - It does require a documentation update and I have updated it (`README.md`, `docs/api.md`).

- [x] :balance_scale:
  - The contribution will be subject to The MIT license, and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in CONTRIBUTING.md.
